### PR TITLE
chore(ci): add GitHub Actions monorepo CI with Turborepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,159 @@
+name: Monorepo CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+jobs:
+  lint:
+    name: Lint (Turbo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint all packages
+        run: pnpm turbo run lint
+
+  test:
+    name: Test (Turbo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm turbo run test
+
+  build:
+    name: Build (Turbo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm turbo run build
+
+  mobile-expo-check:
+    name: Mobile Check (Expo, non-Gradle)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Expo/mobile lint script
+        run: pnpm --filter mobile lint
+
+      - name: Expo/mobile test script
+        run: pnpm --filter mobile test
+
+      - name: TODO - Enable Android Gradle checks when project exists
+        run: |
+          echo "Android Gradle project is not committed yet."
+          echo "Enable these when gradlew exists:"
+          echo "  ./gradlew assembleDebug"
+          echo "  ./gradlew testDebugUnitTest"

--- a/docs/AURA/06_development/ci_cd_pipeline.md
+++ b/docs/AURA/06_development/ci_cd_pipeline.md
@@ -1,3 +1,160 @@
 # CI/CD Pipeline
 
-<!-- Add content here -->
+This repository uses GitHub Actions and Turborepo to run monorepo CI on every relevant
+branch update and pull request.
+
+## Workflow Location
+
+- Workflow file: `.github/workflows/ci.yml`
+- CI scope: monorepo root (`apps/*`, `services/*`, `packages/*`)
+- Package manager in CI: pnpm (`pnpm install --frozen-lockfile`)
+
+## Triggers
+
+The CI workflow runs on:
+
+- `push` to:
+  - `main`
+  - `develop`
+- all `pull_request` events
+
+This ensures status checks are visible on PRs and can be enforced via branch protection.
+
+## Pipeline Jobs
+
+The workflow is split into independent jobs so each appears as a dedicated status check.
+
+### `Lint (Turbo)`
+
+- Installs dependencies from repo root
+- Restores local Turbo cache (`.turbo`)
+- Runs:
+
+```bash
+pnpm turbo run lint
+```
+
+### `Test (Turbo)`
+
+- Installs dependencies from repo root
+- Restores local Turbo cache (`.turbo`)
+- Runs:
+
+```bash
+pnpm turbo run test
+```
+
+### `Build (Turbo)`
+
+- Installs dependencies from repo root
+- Restores local Turbo cache (`.turbo`)
+- Runs:
+
+```bash
+pnpm turbo run build
+```
+
+### `Mobile Check (Expo, non-Gradle)`
+
+Current mobile app setup is Expo-managed (`apps/mobile`) and does not include a committed
+native Android Gradle wrapper yet. This job currently runs:
+
+```bash
+pnpm --filter mobile lint
+pnpm --filter mobile test
+```
+
+It also includes a TODO reminder for future Android native CI:
+
+- `./gradlew assembleDebug`
+- `./gradlew testDebugUnitTest`
+
+## Caching Strategy
+
+CI uses two cache layers:
+
+1. **pnpm dependency cache**
+   - Enabled through `actions/setup-node` with `cache: pnpm`
+2. **Turbo local task cache**
+   - Restored via `actions/cache` on `.turbo`
+   - Keyed by OS + branch + lockfile + turbo config
+
+Optional remote cache wiring is supported with:
+
+- `TURBO_TOKEN` (GitHub secret)
+- `TURBO_TEAM` (GitHub secret)
+
+If these are present, Turbo can use remote cache in addition to local cache restore.
+
+## Performance Controls
+
+- `concurrency` is enabled to cancel stale, in-progress runs for the same ref
+- Job timeouts are set to avoid hanging workers
+- Cache restore keys allow partial cache reuse across branch runs
+
+These controls are aimed at keeping CI under the project target runtime for clean runs.
+
+## Failure Behavior
+
+Pipeline jobs fail automatically when any command exits non-zero:
+
+- lint errors fail `Lint (Turbo)`
+- test failures fail `Test (Turbo)`
+- compile/build failures fail `Build (Turbo)`
+
+Because jobs are separated, PR checks clearly show which stage failed.
+
+## Frontend and Backend Coverage
+
+Coverage is achieved from root-level Turbo orchestration:
+
+- frontend app: `apps/mobile`
+- backend service: `services/api`
+- shared packages: `packages/*`
+
+Running Turbo from the root allows dependency graph-aware task execution across all
+workspace packages.
+
+## GitHub Branch Protection Setup
+
+Recommended required checks:
+
+- `Lint (Turbo)`
+- `Test (Turbo)`
+- `Build (Turbo)`
+- `Mobile Check (Expo, non-Gradle)`
+
+Configure these in GitHub branch protection rules for `main` and `develop` when ready.
+
+## Future Android Native CI Enablement
+
+When a committed Android Gradle project exists (for example `apps/mobile/android/gradlew`
+or a dedicated `apps/android/gradlew`), add a new `android` job with:
+
+1. Java setup
+2. Android SDK setup
+3. Gradle cache setup
+4. Native build and test commands:
+   - `./gradlew assembleDebug`
+   - `./gradlew testDebugUnitTest`
+
+Until then, CI intentionally keeps mobile checks at Expo/JS level.
+
+## Troubleshooting
+
+### Cache misses after lockfile changes
+
+Expected behavior. Updating `pnpm-lock.yaml` invalidates dependency and Turbo cache keys.
+
+### Turbo command appears to skip expected packages
+
+Check:
+
+- package scripts in each workspace (`lint`, `test`, `build`)
+- `turbo.json` task definitions
+- package naming/filter assumptions
+
+### Mobile lint/test passes without real checks
+
+Some scripts are currently placeholders (`echo ...`). Replace them with real lint/test
+commands in workspace `package.json` files as those checks are implemented.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,4 @@ pnpm lint
 - [MVP Issues Registry](issues/AURA_Issues_Registry.md)
 - [Development Setup](AURA/06_development/dev_setup.md)
 - [API Design](AURA/06_development/api_design.md)
+- [CI/CD Pipeline](AURA/06_development/ci_cd_pipeline.md)


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions CI workflow for the monorepo and documents how it works.

- **Workflow:** `.github/workflows/ci.yml` runs on push to `main`/`develop` and on all pull requests. It installs dependencies from the repo root with `pnpm install --frozen-lockfile`, then runs `turbo run lint`, `turbo run test`, and `turbo run build` in separate jobs for clear PR status checks. pnpm and local Turborepo cache (`.turbo`) are restored between runs; optional remote Turbo cache is supported via `TURBO_TOKEN` and `TURBO_TEAM` secrets.
- **Mobile:** A dedicated job runs Expo/mobile workspace scripts (`pnpm --filter mobile lint` / `test`) and documents future Android Gradle steps (`assembleDebug`, `testDebugUnitTest`) when a native project is committed.
- **Docs:** Filled in `docs/AURA/06_development/ci_cd_pipeline.md` and linked from `docs/README.md`.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `chore`: Maintenance, config, or tooling
- [ ] `docs`: Documentation only
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `test`: Adding or updating tests

_Includes documentation updates in `docs/` for the CI pipeline._

## Related Issue

<!-- Link when available, e.g. Closes #4 -->

## Checklist

- [x] Code follows project coding guidelines (ESLint, Prettier)
- [x] Self-review completed
- [x] Comments added for complex logic where needed
- [x] Documentation updated if applicable
- [x] No new warnings introduced
