### PR TITLE
feat(mobile): add Expo API client layer with auth refresh and error mapping

### DIFF
--- a/apps/mobile/lib/api/__tests__/auth-flow.test.ts
+++ b/apps/mobile/lib/api/__tests__/auth-flow.test.ts
@@ -1,0 +1,232 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ApiClient } from '../client';
+import type { TokenStore } from '../token-store';
+
+class MemoryTokenStore implements TokenStore {
+  private accessToken: string | null;
+  private refreshToken: string | null;
+
+  constructor(tokens: { accessToken: string | null; refreshToken: string | null }) {
+    this.accessToken = tokens.accessToken;
+    this.refreshToken = tokens.refreshToken;
+  }
+
+  async getAccessToken(): Promise<string | null> {
+    return this.accessToken;
+  }
+
+  async getRefreshToken(): Promise<string | null> {
+    return this.refreshToken;
+  }
+
+  async setAccessToken(token: string): Promise<void> {
+    this.accessToken = token;
+  }
+
+  async setRefreshToken(token: string): Promise<void> {
+    this.refreshToken = token;
+  }
+
+  async clear(): Promise<void> {
+    this.accessToken = null;
+    this.refreshToken = null;
+  }
+}
+
+function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let rawBody = '';
+    request.on('data', (chunk) => {
+      rawBody += chunk.toString();
+    });
+    request.on('end', () => {
+      if (!rawBody) {
+        resolve(undefined);
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(rawBody));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on('error', reject);
+  });
+}
+
+function json(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader('Content-Type', 'application/json');
+  response.end(JSON.stringify(payload));
+}
+
+describe('ApiClient auth flow integration', () => {
+  const servers: Array<ReturnType<typeof createServer>> = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+              resolve();
+            });
+          }),
+      ),
+    );
+    servers.length = 0;
+  });
+
+  it('injects bearer token and retries once after refresh on 401', async () => {
+    const authHeaders: Array<string | undefined> = [];
+    let refreshCalls = 0;
+
+    const server = createServer(async (request, response) => {
+      if (request.url === '/protected') {
+        const authHeader = request.headers.authorization;
+        authHeaders.push(authHeader);
+
+        if (authHeader === 'Bearer new-access-token') {
+          json(response, 200, { id: 'user_1' });
+          return;
+        }
+
+        json(response, 401, {
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Expired token',
+            retryable: false,
+          },
+        });
+        return;
+      }
+
+      if (request.url === '/auth/token') {
+        refreshCalls += 1;
+        const payload = (await readJsonBody(request)) as { refreshToken?: string } | undefined;
+        if (payload?.refreshToken === 'good-refresh-token') {
+          json(response, 200, {
+            sessionId: 'session_1',
+            accessToken: 'new-access-token',
+            tokenType: 'Bearer',
+            scope: null,
+            expiresIn: 3600,
+          });
+          return;
+        }
+
+        json(response, 401, {
+          error: {
+            code: 'INVALID_REFRESH_TOKEN',
+            message: 'Refresh token invalid',
+            retryable: false,
+          },
+        });
+        return;
+      }
+
+      json(response, 404, {
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Route not found',
+          retryable: false,
+        },
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, resolve);
+    });
+    servers.push(server);
+    const address = server.address() as AddressInfo;
+
+    const tokenStore = new MemoryTokenStore({
+      accessToken: 'old-access-token',
+      refreshToken: 'good-refresh-token',
+    });
+    const apiClient = new ApiClient({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      tokenStore,
+    });
+
+    const result = await apiClient.request<{ id: string }>({
+      path: '/protected',
+      method: 'GET',
+    });
+
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect(result.data.id).toBe('user_1');
+    }
+    expect(refreshCalls).toBe(1);
+    expect(authHeaders).toEqual(['Bearer old-access-token', 'Bearer new-access-token']);
+    expect(await tokenStore.getAccessToken()).toBe('new-access-token');
+  });
+
+  it('returns auth_refresh_failed when refresh endpoint fails', async () => {
+    const server = createServer(async (request, response) => {
+      if (request.url === '/protected') {
+        json(response, 401, {
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Expired token',
+            retryable: false,
+          },
+        });
+        return;
+      }
+
+      if (request.url === '/auth/token') {
+        json(response, 401, {
+          error: {
+            code: 'INVALID_REFRESH_TOKEN',
+            message: 'Refresh token invalid',
+            retryable: false,
+          },
+        });
+        return;
+      }
+
+      json(response, 404, {
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Route not found',
+          retryable: false,
+        },
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, resolve);
+    });
+    servers.push(server);
+    const address = server.address() as AddressInfo;
+
+    const tokenStore = new MemoryTokenStore({
+      accessToken: 'expired-token',
+      refreshToken: 'bad-refresh-token',
+    });
+    const apiClient = new ApiClient({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      tokenStore,
+    });
+
+    const result = await apiClient.request<{ id: string }>({
+      path: '/protected',
+      method: 'GET',
+    });
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') {
+      expect(result.error.type).toBe('auth_refresh_failed');
+    }
+  });
+});

--- a/apps/mobile/lib/api/__tests__/result.test.ts
+++ b/apps/mobile/lib/api/__tests__/result.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapHttpError, mapNetworkError, mapParsingError } from '../result';
+
+describe('ApiResult error mapping', () => {
+  it('maps backend HTTP errors into ApiResult.Error', () => {
+    const result = mapHttpError(401, {
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Token expired',
+        retryable: false,
+      },
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error.type).toBe('http');
+    expect(result.error.status).toBe(401);
+    expect(result.error.code).toBe('UNAUTHORIZED');
+    expect(result.error.message).toBe('Token expired');
+  });
+
+  it('maps network failures to retryable errors', () => {
+    const result = mapNetworkError(new TypeError('Failed to fetch'));
+
+    expect(result.status).toBe('error');
+    expect(result.error.type).toBe('network');
+    expect(result.error.retryable).toBe(true);
+  });
+
+  it('maps JSON parse failures to parsing errors', () => {
+    const result = mapParsingError(new SyntaxError('Unexpected token'));
+
+    expect(result.status).toBe('error');
+    expect(result.error.type).toBe('parsing');
+    expect(result.error.retryable).toBe(false);
+  });
+});

--- a/apps/mobile/lib/api/client.ts
+++ b/apps/mobile/lib/api/client.ts
@@ -1,0 +1,319 @@
+import { getApiBaseUrl } from './config';
+import {
+  apiError,
+  apiSuccess,
+  mapHttpError,
+  mapNetworkError,
+  mapParsingError,
+  mapUnknownError,
+  type ApiFailure,
+  type ApiResult,
+} from './result';
+import type { TokenStore } from './token-store';
+
+const JSON_CONTENT_TYPE = 'application/json';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type ApiRequestOptions<TBody> = {
+  path: string;
+  method?: HttpMethod;
+  body?: TBody;
+  headers?: Record<string, string>;
+  requiresAuth?: boolean;
+  retryOnUnauthorized?: boolean;
+  timeoutMs?: number;
+};
+
+export type RefreshResponse = {
+  accessToken: string;
+  refreshToken?: string;
+  sessionId?: string;
+  tokenType?: string;
+  scope?: string;
+  expiresIn?: number;
+};
+
+type Logger = {
+  debug(message: string, context?: Record<string, unknown>): void;
+};
+
+type FetchLike = typeof fetch;
+
+export type ApiClientOptions = {
+  baseUrl?: string;
+  timeoutMs?: number;
+  fetchFn?: FetchLike;
+  logger?: Logger;
+  tokenStore: TokenStore;
+};
+
+const noopLogger: Logger = {
+  debug: () => undefined,
+};
+
+function makeLogger(): Logger {
+  const isDebugBuild = typeof __DEV__ !== 'undefined' && __DEV__;
+  if (!isDebugBuild) {
+    return noopLogger;
+  }
+
+  return {
+    debug(message, context) {
+      if (context) {
+        console.log(`[ApiClient] ${message}`, context);
+        return;
+      }
+
+      console.log(`[ApiClient] ${message}`);
+    },
+  };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (isAbortError(error)) {
+    return true;
+  }
+
+  return error instanceof TypeError;
+}
+
+function isRefreshResponse(payload: unknown): payload is RefreshResponse {
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  return typeof (payload as RefreshResponse).accessToken === 'string';
+}
+
+function toAbsoluteUrl(baseUrl: string, path: string): string {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
+async function persistTokens(
+  tokenStore: TokenStore,
+  tokens: { accessToken: string | null; refreshToken: string | null },
+): Promise<void> {
+  if (tokens.accessToken) {
+    await tokenStore.setAccessToken(tokens.accessToken);
+  }
+
+  if (tokens.refreshToken) {
+    await tokenStore.setRefreshToken(tokens.refreshToken);
+  }
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly tokenStore: TokenStore;
+  private readonly fetchFn: FetchLike;
+  private readonly logger: Logger;
+
+  constructor(options: ApiClientOptions) {
+    this.baseUrl = getApiBaseUrl({ baseUrl: options.baseUrl });
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.tokenStore = options.tokenStore;
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.logger = options.logger ?? makeLogger();
+  }
+
+  async request<TResponse, TBody = unknown>(
+    options: ApiRequestOptions<TBody>,
+  ): Promise<ApiResult<TResponse>> {
+    return this.requestInternal<TResponse, TBody>(options, true);
+  }
+
+  async refreshSession(): Promise<ApiResult<RefreshResponse>> {
+    return this.refreshAccessToken();
+  }
+
+  private async requestInternal<TResponse, TBody>(
+    options: ApiRequestOptions<TBody>,
+    canRetryAfterRefresh: boolean,
+  ): Promise<ApiResult<TResponse>> {
+    const requestInit = await this.buildRequestInit(options);
+    const url = toAbsoluteUrl(this.baseUrl, options.path);
+    this.logger.debug('Sending request', {
+      method: requestInit.method,
+      url,
+      requiresAuth: options.requiresAuth ?? true,
+    });
+
+    let response: Response;
+    try {
+      response = await this.fetchWithTimeout(url, requestInit, options.timeoutMs ?? this.timeoutMs);
+    } catch (error) {
+      return isNetworkError(error) ? mapNetworkError(error) : mapUnknownError(error);
+    }
+
+    if ((options.requiresAuth ?? true) && response.status === 401 && canRetryAfterRefresh) {
+      const refreshResult = await this.refreshAccessToken();
+      if (refreshResult.status === 'error') {
+        return apiError({
+          type: 'auth_refresh_failed',
+          message: 'Session expired. Please sign in again.',
+          code: refreshResult.error.code,
+          status: refreshResult.error.status,
+          retryable: false,
+          cause: refreshResult.error,
+        });
+      }
+
+      return this.requestInternal<TResponse, TBody>(
+        {
+          ...options,
+          retryOnUnauthorized: false,
+        },
+        false,
+      );
+    }
+
+    return this.mapResponseToResult<TResponse>(response);
+  }
+
+  private async buildRequestInit<TBody>(options: ApiRequestOptions<TBody>): Promise<RequestInit> {
+    const method = options.method ?? 'GET';
+    const headers = new Headers(options.headers ?? {});
+
+    headers.set('Accept', JSON_CONTENT_TYPE);
+    if (!headers.has('Content-Type') && options.body !== undefined) {
+      headers.set('Content-Type', JSON_CONTENT_TYPE);
+    }
+
+    if (options.requiresAuth ?? true) {
+      const accessToken = await this.tokenStore.getAccessToken();
+      if (accessToken) {
+        headers.set('Authorization', `Bearer ${accessToken}`);
+      }
+    }
+
+    const body =
+      options.body === undefined || method === 'GET' ? undefined : JSON.stringify(options.body);
+
+    return {
+      method,
+      headers,
+      body,
+    };
+  }
+
+  private async mapResponseToResult<TResponse>(response: Response): Promise<ApiResult<TResponse>> {
+    const parsedBody = await this.parseResponseBody(response);
+    if (parsedBody.status !== 'success') {
+      if (parsedBody.status === 'error') {
+        return parsedBody;
+      }
+
+      return mapUnknownError(new Error('Unexpected loading state while parsing response.'));
+    }
+
+    if (!response.ok) {
+      return mapHttpError(response.status, parsedBody.data);
+    }
+
+    return apiSuccess(parsedBody.data as TResponse);
+  }
+
+  private async parseResponseBody(response: Response): Promise<ApiResult<unknown>> {
+    if (response.status === 204) {
+      return apiSuccess(undefined);
+    }
+
+    let rawBody = '';
+    try {
+      rawBody = await response.text();
+    } catch (error) {
+      return mapUnknownError(error);
+    }
+
+    if (!rawBody) {
+      return apiSuccess(undefined);
+    }
+
+    try {
+      return apiSuccess(JSON.parse(rawBody));
+    } catch (error) {
+      return mapParsingError(error);
+    }
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    requestInit: RequestInit,
+    timeoutMs: number,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      return await this.fetchFn(url, {
+        ...requestInit,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async refreshAccessToken(): Promise<ApiResult<RefreshResponse>> {
+    const refreshToken = await this.tokenStore.getRefreshToken();
+    if (!refreshToken) {
+      return apiError({
+        type: 'auth_refresh_failed',
+        code: 'MISSING_REFRESH_TOKEN',
+        message: 'No refresh token found.',
+        retryable: false,
+      });
+    }
+
+    const refreshResult = await this.requestInternal<unknown, { refreshToken: string }>(
+      {
+        path: '/auth/token',
+        method: 'POST',
+        body: { refreshToken },
+        requiresAuth: false,
+        retryOnUnauthorized: false,
+      },
+      false,
+    );
+
+    if (refreshResult.status === 'error') {
+      return refreshResult;
+    }
+    if (refreshResult.status !== 'success') {
+      return mapUnknownError(new Error('Unexpected loading state during token refresh.'));
+    }
+
+    if (!isRefreshResponse(refreshResult.data)) {
+      return apiError({
+        type: 'parsing',
+        code: 'INVALID_REFRESH_PAYLOAD',
+        message: 'Refresh endpoint returned an invalid payload.',
+        retryable: false,
+      });
+    }
+
+    await persistTokens(this.tokenStore, {
+      accessToken: refreshResult.data.accessToken,
+      refreshToken: refreshResult.data.refreshToken ?? refreshToken,
+    });
+
+    this.logger.debug('Access token refreshed successfully.');
+    return apiSuccess(refreshResult.data);
+  }
+}
+
+export function isApiFailure<T>(result: ApiResult<T>): result is ApiFailure {
+  return result.status === 'error';
+}

--- a/apps/mobile/lib/api/config.ts
+++ b/apps/mobile/lib/api/config.ts
@@ -1,0 +1,38 @@
+export type ApiEnvironment = 'development' | 'staging' | 'production';
+
+const DEFAULT_BASE_URLS: Record<ApiEnvironment, string> = {
+  development: 'http://10.0.2.2:8787',
+  staging: 'https://staging.api.aura.app',
+  production: 'https://api.aura.app',
+};
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+function resolveApiEnvironment(value?: string): ApiEnvironment {
+  if (value === 'production' || value === 'staging' || value === 'development') {
+    return value;
+  }
+
+  return 'development';
+}
+
+export type ApiConfigOptions = {
+  baseUrl?: string;
+  environment?: ApiEnvironment;
+};
+
+export function getApiBaseUrl(options: ApiConfigOptions = {}): string {
+  if (options.baseUrl) {
+    return normalizeBaseUrl(options.baseUrl);
+  }
+
+  const envBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
+  if (envBaseUrl) {
+    return normalizeBaseUrl(envBaseUrl);
+  }
+
+  const environment = options.environment ?? resolveApiEnvironment(process.env.EXPO_PUBLIC_API_ENV);
+  return normalizeBaseUrl(DEFAULT_BASE_URLS[environment]);
+}

--- a/apps/mobile/lib/api/index.ts
+++ b/apps/mobile/lib/api/index.ts
@@ -1,0 +1,17 @@
+import { ApiClient } from './client';
+import { createAuthApiService } from './services/auth-api-service';
+import { createUserApiService } from './services/user-api-service';
+import { AsyncStorageTokenStore } from './token-store';
+
+const tokenStore = new AsyncStorageTokenStore();
+const apiClient = new ApiClient({ tokenStore });
+
+export const authApiService = createAuthApiService(apiClient, tokenStore);
+export const userApiService = createUserApiService();
+
+export * from './client';
+export * from './config';
+export * from './result';
+export * from './token-store';
+export * from './services/auth-api-service';
+export * from './services/user-api-service';

--- a/apps/mobile/lib/api/result.ts
+++ b/apps/mobile/lib/api/result.ts
@@ -1,0 +1,94 @@
+export type ApiErrorType =
+  | 'network'
+  | 'http'
+  | 'parsing'
+  | 'auth_refresh_failed'
+  | 'not_implemented'
+  | 'unknown';
+
+export type ApiErrorDetails = {
+  type: ApiErrorType;
+  message: string;
+  code?: string;
+  status?: number;
+  retryable?: boolean;
+  cause?: unknown;
+};
+
+export type ApiSuccess<T> = {
+  status: 'success';
+  data: T;
+};
+
+export type ApiFailure = {
+  status: 'error';
+  error: ApiErrorDetails;
+};
+
+export type ApiLoading = {
+  status: 'loading';
+};
+
+export type ApiResult<T> = ApiSuccess<T> | ApiFailure | ApiLoading;
+
+export function apiSuccess<T>(data: T): ApiSuccess<T> {
+  return { status: 'success', data };
+}
+
+export function apiLoading(): ApiLoading {
+  return { status: 'loading' };
+}
+
+export function apiError(error: ApiErrorDetails): ApiFailure {
+  return { status: 'error', error };
+}
+
+type BackendErrorPayload = {
+  error?: {
+    code?: string;
+    message?: string;
+    retryable?: boolean;
+  };
+};
+
+export function mapHttpError(status: number, payload?: unknown): ApiFailure {
+  const backendPayload = payload as BackendErrorPayload | undefined;
+  const code = backendPayload?.error?.code ?? `HTTP_${status}`;
+  const message = backendPayload?.error?.message ?? `Request failed with HTTP ${status}`;
+  const retryable = backendPayload?.error?.retryable ?? status >= 500;
+
+  return apiError({
+    type: 'http',
+    status,
+    code,
+    message,
+    retryable,
+  });
+}
+
+export function mapParsingError(cause: unknown): ApiFailure {
+  return apiError({
+    type: 'parsing',
+    message: 'Failed to parse API response.',
+    retryable: false,
+    cause,
+  });
+}
+
+export function mapNetworkError(cause: unknown): ApiFailure {
+  return apiError({
+    type: 'network',
+    message: 'Network request failed. Check your connection and try again.',
+    retryable: true,
+    cause,
+  });
+}
+
+export function mapUnknownError(cause: unknown): ApiFailure {
+  return apiError({
+    type: 'unknown',
+    message: 'Unexpected error while calling API.',
+    retryable: false,
+    cause,
+  });
+}

--- a/apps/mobile/lib/api/services/auth-api-service.ts
+++ b/apps/mobile/lib/api/services/auth-api-service.ts
@@ -1,0 +1,103 @@
+import { ApiClient } from '../client';
+import { apiError, type ApiResult } from '../result';
+import type { TokenStore } from '../token-store';
+
+export type LoginRequest = {
+  code: string;
+  redirectUri?: string;
+  codeVerifier?: string;
+};
+
+export type AuthUser = {
+  sub: string;
+  email: string | null;
+  name: string | null;
+  picture: string | null;
+};
+
+export type LoginResponse = {
+  sessionId: string;
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  scope: string | null;
+  expiresIn: number;
+  user: AuthUser;
+};
+
+export type RefreshTokenResponse = {
+  sessionId: string;
+  accessToken: string;
+  tokenType: string;
+  scope: string | null;
+  expiresIn: number;
+};
+
+export interface AuthApiService {
+  login(request: LoginRequest): Promise<ApiResult<LoginResponse>>;
+  refreshToken(): Promise<ApiResult<RefreshTokenResponse>>;
+  logout(): Promise<ApiResult<void>>;
+}
+
+class AuthApiServiceImpl implements AuthApiService {
+  constructor(
+    private readonly apiClient: ApiClient,
+    private readonly tokenStore: TokenStore,
+  ) {}
+
+  async login(request: LoginRequest): Promise<ApiResult<LoginResponse>> {
+    const result = await this.apiClient.request<LoginResponse, LoginRequest>({
+      path: '/auth/google',
+      method: 'POST',
+      body: request,
+      requiresAuth: false,
+      retryOnUnauthorized: false,
+    });
+
+    if (result.status === 'success') {
+      await this.tokenStore.setAccessToken(result.data.accessToken);
+      await this.tokenStore.setRefreshToken(result.data.refreshToken);
+    }
+
+    return result;
+  }
+
+  async refreshToken(): Promise<ApiResult<RefreshTokenResponse>> {
+    const result = await this.apiClient.refreshSession();
+    if (result.status === 'error') {
+      return result;
+    }
+    if (result.status !== 'success') {
+      return apiError({
+        type: 'unknown',
+        code: 'UNEXPECTED_LOADING_STATE',
+        message: 'Unexpected loading state during token refresh.',
+        retryable: false,
+      });
+    }
+
+    return {
+      status: 'success',
+      data: {
+        sessionId: result.data.sessionId ?? '',
+        accessToken: result.data.accessToken,
+        tokenType: result.data.tokenType ?? 'Bearer',
+        scope: result.data.scope ?? null,
+        expiresIn: result.data.expiresIn ?? 0,
+      },
+    };
+  }
+
+  async logout(): Promise<ApiResult<void>> {
+    return apiError({
+      type: 'not_implemented',
+      code: 'NOT_IMPLEMENTED',
+      message: 'Logout endpoint is not available in the backend yet.',
+      retryable: false,
+    });
+  }
+}
+
+export function createAuthApiService(apiClient: ApiClient, tokenStore: TokenStore): AuthApiService {
+  return new AuthApiServiceImpl(apiClient, tokenStore);
+}

--- a/apps/mobile/lib/api/services/user-api-service.ts
+++ b/apps/mobile/lib/api/services/user-api-service.ts
@@ -1,0 +1,27 @@
+import { apiError, type ApiResult } from '../result';
+
+export type MeResponse = {
+  id: string;
+  email: string;
+  name: string | null;
+  picture: string | null;
+};
+
+export interface UserApiService {
+  getMe(): Promise<ApiResult<MeResponse>>;
+}
+
+class UserApiServiceImpl implements UserApiService {
+  async getMe(): Promise<ApiResult<MeResponse>> {
+    return apiError({
+      type: 'not_implemented',
+      code: 'NOT_IMPLEMENTED',
+      message: 'The /user/me endpoint is not available in the backend yet.',
+      retryable: false,
+    });
+  }
+}
+
+export function createUserApiService(): UserApiService {
+  return new UserApiServiceImpl();
+}

--- a/apps/mobile/lib/api/token-store.ts
+++ b/apps/mobile/lib/api/token-store.ts
@@ -1,0 +1,50 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ACCESS_TOKEN_KEY = 'api.accessToken';
+const REFRESH_TOKEN_KEY = 'api.refreshToken';
+
+export type StoredTokens = {
+  accessToken: string | null;
+  refreshToken: string | null;
+};
+
+export interface TokenStore {
+  getAccessToken(): Promise<string | null>;
+  getRefreshToken(): Promise<string | null>;
+  setAccessToken(token: string): Promise<void>;
+  setRefreshToken(token: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class AsyncStorageTokenStore implements TokenStore {
+  async getAccessToken(): Promise<string | null> {
+    return AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+  }
+
+  async getRefreshToken(): Promise<string | null> {
+    return AsyncStorage.getItem(REFRESH_TOKEN_KEY);
+  }
+
+  async setAccessToken(token: string): Promise<void> {
+    await AsyncStorage.setItem(ACCESS_TOKEN_KEY, token);
+  }
+
+  async setRefreshToken(token: string): Promise<void> {
+    await AsyncStorage.setItem(REFRESH_TOKEN_KEY, token);
+  }
+
+  async clear(): Promise<void> {
+    await AsyncStorage.removeItem(ACCESS_TOKEN_KEY);
+    await AsyncStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+}
+
+export async function saveTokens(tokenStore: TokenStore, tokens: StoredTokens): Promise<void> {
+  if (tokens.accessToken) {
+    await tokenStore.setAccessToken(tokens.accessToken);
+  }
+
+  if (tokens.refreshToken) {
+    await tokenStore.setRefreshToken(tokens.refreshToken);
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,7 +7,9 @@
     "dev": "expo start -c",
     "start": "expo start -c",
     "lint": "echo 'No lint configured'",
-    "test": "echo 'No tests'",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "android": "expo start -c --android",
     "ios": "expo start -c --ios",
     "web": "expo start -c --web",
@@ -47,10 +49,12 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
+    "@types/node": "^22.19.17",
     "@types/react": "~19.1.10",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "vitest": "^4.1.2"
   },
   "private": true
 }

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['lib/api/__tests__/**/*.test.ts'],
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@babel/core':
         specifier: ^7.26.0
         version: 7.29.0
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
       '@types/react':
         specifier: ~19.1.10
         version: 19.1.17
@@ -120,6 +123,9 @@ importers:
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.17)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/ai-engine:
     devDependencies:


### PR DESCRIPTION
## Summary
- add a reusable Expo API client layer for mobile network calls
- implement bearer token injection with one-time refresh-and-retry on 401
- add centralized `ApiResult<T>` mapping and tests for error mapping/auth flow

## Test plan
- [x] pnpm --filter mobile typecheck
- [x] pnpm --filter mobile test

Made with [Cursor](https://cursor.com)