### PR TITLE
feat(api): add user sessions, logout, profile endpoint, and rate limits

### DIFF
--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,49 @@
+# Database Schema
+
+This document describes the authentication data model used by the API service.
+
+## `users`
+
+Stores one profile per Google identity.
+
+| Column | Type | Constraints | Description |
+| --- | --- | --- | --- |
+| `user_id` | `TEXT` | `PRIMARY KEY` | Internal UUID for the user. |
+| `google_sub` | `TEXT` | `NOT NULL`, `UNIQUE` | Google subject identifier from userinfo. |
+| `email` | `TEXT` | nullable | Latest known user email. |
+| `name` | `TEXT` | nullable | Latest known display name. |
+| `picture` | `TEXT` | nullable | Latest known profile image URL. |
+| `created_at` | `INTEGER` | `NOT NULL` | Creation time in Unix milliseconds. |
+| `last_login_at` | `INTEGER` | `NOT NULL` | Last successful OAuth login in Unix milliseconds. |
+
+## `auth_sessions`
+
+Stores API session credentials linked to a user.
+
+| Column | Type | Constraints | Description |
+| --- | --- | --- | --- |
+| `session_id` | `TEXT` | `PRIMARY KEY` | Session UUID. |
+| `user_id` | `TEXT` | `FOREIGN KEY` -> `users.user_id` | Owning user ID. |
+| `access_token` | `TEXT` | `NOT NULL` | Current active OAuth access token. |
+| `previous_access_token` | `TEXT` | nullable | Previous token retained for rotation grace. |
+| `refresh_token` | `TEXT` | `NOT NULL`, `UNIQUE` | Refresh token for Google token refresh flow. |
+| `expires_at` | `INTEGER` | nullable during migration | Access token expiry time in Unix milliseconds. |
+| `created_at` | `INTEGER` | nullable during migration | Session creation time in Unix milliseconds. |
+| `token_type` | `TEXT` | nullable during migration | OAuth token type (`Bearer`). |
+| `scope` | `TEXT` | nullable | Granted OAuth scope string. |
+| `updated_at` | `INTEGER` | nullable during migration | Last session update in Unix milliseconds. |
+
+## Indexes
+
+- `idx_users_google_sub` on `users(google_sub)`
+- `idx_auth_sessions_access_token` on `auth_sessions(access_token)`
+- `idx_auth_sessions_user_id` on `auth_sessions(user_id)`
+
+## Migration Notes
+
+The API runs migration-safe startup SQL in `services/api/src/auth/session-store.ts`:
+
+- Creates `users` and `auth_sessions` tables if missing.
+- Adds required columns to older `auth_sessions` schemas if needed.
+- Backfills `users` from legacy `auth_sessions.google_sub`.
+- Backfills `auth_sessions.user_id`, `expires_at`, and timestamp defaults.

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -2,17 +2,28 @@ import { Hono } from 'hono'
 import { ApiError, type ErrorPayload } from './errors.js'
 import { createCorsMiddleware } from './middleware/cors.js'
 import { validateJsonBodyMiddleware } from './middleware/json-body.js'
+import { createRateLimitMiddleware, getClientIp } from './middleware/rate-limit.js'
 import { authRoutes } from './routes/auth.js'
 import { healthRoutes } from './routes/health.js'
 import { protectedRoutes } from './routes/protected.js'
+import { userRoutes } from './routes/user.js'
 
 export const app = new Hono()
+const authRateLimitMiddleware = createRateLimitMiddleware({
+  limit: 20,
+  windowMs: 60_000,
+  errorCode: 'RATE_LIMITED',
+  errorMessage: 'Rate limit exceeded for auth endpoints',
+  keyGenerator: (c) => `auth-ip:${getClientIp(c)}`
+})
 
 app.use('*', createCorsMiddleware())
 app.use('*', validateJsonBodyMiddleware)
+app.use('/auth/*', authRateLimitMiddleware)
 app.route('/', healthRoutes)
 app.route('/auth', authRoutes)
 app.route('/protected', protectedRoutes)
+app.route('/user', userRoutes)
 
 app.notFound((c) => {
   return c.json(

--- a/services/api/src/auth/middleware.ts
+++ b/services/api/src/auth/middleware.ts
@@ -1,11 +1,11 @@
 import type { MiddlewareHandler } from 'hono'
 import { ApiError } from '../errors.js'
 import type { AuthService } from './service.js'
-import type { AuthSession } from './types.js'
+import type { AuthenticatedContext } from './types.js'
 
-const AUTH_CONTEXT_KEY = 'authSession'
+const AUTH_CONTEXT_KEY = 'authContext'
 
-function parseBearerToken(authorizationHeader: string | undefined): string {
+export function parseBearerToken(authorizationHeader: string | undefined): string {
   if (!authorizationHeader) {
     throw new ApiError(401, 'UNAUTHORIZED', 'Missing Authorization header', false)
   }
@@ -22,7 +22,12 @@ export function createAuthMiddleware(authService: AuthService): MiddlewareHandle
   return async (c, next) => {
     const bearerToken = parseBearerToken(c.req.header('authorization'))
     const session = await authService.validateOrRefreshAccessToken(bearerToken)
-    c.set(AUTH_CONTEXT_KEY, session)
+    const context: AuthenticatedContext = {
+      userId: session.userId,
+      sessionId: session.id,
+      accessToken: session.accessToken
+    }
+    c.set(AUTH_CONTEXT_KEY, context)
 
     if (session.accessToken !== bearerToken) {
       c.header('x-refreshed-access-token', session.accessToken)
@@ -32,11 +37,15 @@ export function createAuthMiddleware(authService: AuthService): MiddlewareHandle
   }
 }
 
-export function getAuthSession(c: { get: (key: string) => unknown }): AuthSession {
-  const session = c.get(AUTH_CONTEXT_KEY)
-  if (!session) {
+export function getAuthContext(c: { get: (key: string) => unknown }): AuthenticatedContext {
+  const authContext = c.get(AUTH_CONTEXT_KEY)
+  if (!authContext) {
     throw new ApiError(401, 'UNAUTHORIZED', 'Missing authenticated session', false)
   }
 
-  return session as AuthSession
+  return authContext as AuthenticatedContext
+}
+
+export function getAuthenticatedUserId(c: { get: (key: string) => unknown }): string {
+  return getAuthContext(c).userId
 }

--- a/services/api/src/auth/service.ts
+++ b/services/api/src/auth/service.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from 'node:crypto'
 import type { AuthConfig } from './config.js'
-import type { AuthResult, AuthSession, RefreshResult } from './types.js'
+import type { AuthResult, AuthSession, RefreshResult, User } from './types.js'
 import { ApiError } from '../errors.js'
 import { GoogleOAuthClient } from './google-client.js'
 import { AuthSessionStore } from './session-store.js'
@@ -44,40 +43,36 @@ export class AuthService {
 
     const user = await this.client.fetchUserInfo(tokens.access_token)
     const expiresIn = Math.max(tokens.expires_in, 1)
-    const accessTokenExpiresAt = Date.now() + expiresIn * 1000
+    const expiresAt = Date.now() + expiresIn * 1000
+    const persistedUser = await this.store.findOrCreateUser({
+      sub: user.sub,
+      email: user.email,
+      name: user.name,
+      picture: user.picture
+    })
 
-    const session = await this.store.upsertSession({
-      sessionId: randomUUID(),
-      googleSub: user.sub,
-      email: user.email ?? null,
-      name: user.name ?? null,
-      picture: user.picture ?? null,
+    const session = await this.store.createSession({
+      userId: persistedUser.id,
       accessToken: tokens.access_token,
-      previousAccessToken: null,
       refreshToken: tokens.refresh_token,
       scope: tokens.scope ?? this.config.googleScopes,
       tokenType: tokens.token_type,
-      accessTokenExpiresAt
+      expiresAt
     })
 
     return {
-      sessionId: session.sessionId,
+      sessionId: session.id,
       accessToken: session.accessToken,
       refreshToken: session.refreshToken,
       expiresIn,
       scope: session.scope,
       tokenType: session.tokenType,
-      user: {
-        sub: session.googleSub,
-        email: session.email,
-        name: session.name,
-        picture: session.picture
-      }
+      user: persistedUser
     }
   }
 
   async refreshAccessToken(input: RefreshInput): Promise<RefreshResult> {
-    const session = await this.store.findByRefreshToken(input.refreshToken)
+    const session = await this.store.findSessionByRefreshToken(input.refreshToken)
     if (!session) {
       throw new ApiError(401, 'INVALID_REFRESH_TOKEN', 'Refresh token is invalid or revoked', false)
     }
@@ -94,11 +89,11 @@ export class AuthService {
       refreshToken: refreshed.refresh_token ?? session.refreshToken,
       scope: refreshed.scope ?? session.scope,
       tokenType: refreshed.token_type,
-      accessTokenExpiresAt: Date.now() + expiresIn * 1000
+      expiresAt: Date.now() + expiresIn * 1000
     })
 
     return {
-      sessionId: updatedSession.sessionId,
+      sessionId: updatedSession.id,
       accessToken: updatedSession.accessToken,
       expiresIn,
       scope: updatedSession.scope,
@@ -107,13 +102,13 @@ export class AuthService {
   }
 
   async validateOrRefreshAccessToken(accessToken: string): Promise<AuthSession> {
-    const session = await this.store.findByAccessToken(accessToken)
+    const session = await this.store.findSessionByAccessToken(accessToken)
     if (!session) {
       throw new ApiError(401, 'INVALID_ACCESS_TOKEN', 'Access token is invalid or revoked', false)
     }
 
     const now = Date.now()
-    const expiresSoon = now + this.config.accessTokenExpirySkewMs >= session.accessTokenExpiresAt
+    const expiresSoon = now + this.config.accessTokenExpirySkewMs >= session.expiresAt
     if (!expiresSoon) {
       return session
     }
@@ -130,7 +125,25 @@ export class AuthService {
       refreshToken: refreshed.refresh_token ?? session.refreshToken,
       scope: refreshed.scope ?? session.scope,
       tokenType: refreshed.token_type,
-      accessTokenExpiresAt: now + expiresIn * 1000
+      expiresAt: now + expiresIn * 1000
     })
+  }
+
+  async logoutByAccessToken(accessToken: string): Promise<void> {
+    const session = await this.store.findSessionByAccessToken(accessToken)
+    if (!session) {
+      throw new ApiError(401, 'INVALID_ACCESS_TOKEN', 'Access token is invalid or revoked', false)
+    }
+
+    await this.store.deleteSessionById(session.id)
+  }
+
+  async getUserById(userId: string): Promise<User> {
+    const user = await this.store.findUserById(userId)
+    if (!user) {
+      throw new ApiError(404, 'USER_NOT_FOUND', 'Authenticated user was not found', false)
+    }
+
+    return user
   }
 }

--- a/services/api/src/auth/session-store.ts
+++ b/services/api/src/auth/session-store.ts
@@ -1,24 +1,45 @@
 import { dirname } from 'node:path'
 import { mkdir } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
-import type { AuthSession } from './types.js'
+import type { AuthSession, GoogleUserInfo, User } from './types.js'
 
 type UpsertSessionInput = Omit<AuthSession, 'createdAt' | 'updatedAt'>
+type CreateSessionInput = Omit<AuthSession, 'id' | 'createdAt' | 'updatedAt' | 'previousAccessToken'>
+type UpsertUserInput = Pick<GoogleUserInfo, 'sub' | 'email' | 'name' | 'picture'>
 
 type SessionRow = {
   session_id: string
+  user_id: string
+  access_token: string
+  refresh_token: string
+  expires_at: number
+  created_at: number
+  token_type: string
+  scope: string | null
+  previous_access_token: string | null
+  updated_at: number
+}
+
+type UserRow = {
+  user_id: string
+  email: string | null
+  name: string | null
+  picture: string | null
+  created_at: number
+  last_login_at: number
+}
+
+type LegacySessionSeedRow = {
   google_sub: string
   email: string | null
   name: string | null
   picture: string | null
-  access_token: string
-  previous_access_token: string | null
-  refresh_token: string
-  scope: string | null
-  token_type: string
-  access_token_expires_at: number
+}
+
+type LegacyLastLoginRow = {
+  google_sub: string
   created_at: number
-  updated_at: number
 }
 
 export class AuthSessionStore {
@@ -29,54 +50,127 @@ export class AuthSessionStore {
     this.dbPath = dbPath
   }
 
+  async findOrCreateUser(input: UpsertUserInput): Promise<User> {
+    const db = await this.getDb()
+    const now = Date.now()
+    const statement = db.prepare(
+      `
+      SELECT *
+      FROM users
+      WHERE google_sub = ?
+      LIMIT 1
+      `
+    )
+    const existing = statement.get(input.sub) as UserRow | undefined
+
+    if (!existing) {
+      const user: User = {
+        id: randomUUID(),
+        email: input.email ?? null,
+        name: input.name ?? null,
+        picture: input.picture ?? null,
+        createdAt: now,
+        lastLoginAt: now
+      }
+      this.insertUser(db, {
+        userId: user.id,
+        googleSub: input.sub,
+        email: user.email,
+        name: user.name,
+        picture: user.picture,
+        createdAt: user.createdAt,
+        lastLoginAt: user.lastLoginAt
+      })
+      return user
+    }
+
+    const updatedEmail = input.email ?? existing.email
+    const updatedName = input.name ?? existing.name
+    const updatedPicture = input.picture ?? existing.picture
+    const update = db.prepare(
+      `
+      UPDATE users
+      SET
+        email = ?,
+        name = ?,
+        picture = ?,
+        last_login_at = ?
+      WHERE google_sub = ?
+      `
+    )
+    update.run(updatedEmail, updatedName, updatedPicture, now, input.sub)
+
+    return {
+      id: existing.user_id,
+      email: updatedEmail,
+      name: updatedName,
+      picture: updatedPicture,
+      createdAt: existing.created_at,
+      lastLoginAt: now
+    }
+  }
+
+  async findUserById(userId: string): Promise<User | null> {
+    const db = await this.getDb()
+    const statement = db.prepare('SELECT * FROM users WHERE user_id = ? LIMIT 1')
+    const row = statement.get(userId) as UserRow | undefined
+    return row ? this.mapUserRow(row) : null
+  }
+
+  async createSession(input: CreateSessionInput): Promise<AuthSession> {
+    return this.upsertSession({
+      id: randomUUID(),
+      userId: input.userId,
+      accessToken: input.accessToken,
+      refreshToken: input.refreshToken,
+      expiresAt: input.expiresAt,
+      tokenType: input.tokenType,
+      scope: input.scope,
+      previousAccessToken: null
+    })
+  }
+
   async upsertSession(input: UpsertSessionInput): Promise<AuthSession> {
     const db = await this.getDb()
     const now = Date.now()
-    const existing = await this.findBySessionId(input.sessionId)
+    const existing = await this.findSessionById(input.id)
     const createdAt = existing?.createdAt ?? now
 
-    const statement = db.prepare(`
+    const statement = db.prepare(
+      `
       INSERT INTO auth_sessions (
         session_id,
-        google_sub,
-        email,
-        name,
-        picture,
+        user_id,
         access_token,
         previous_access_token,
         refresh_token,
-        scope,
-        token_type,
-        access_token_expires_at,
+        expires_at,
         created_at,
+        token_type,
+        scope,
         updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(session_id) DO UPDATE SET
-        google_sub = excluded.google_sub,
-        email = excluded.email,
-        name = excluded.name,
-        picture = excluded.picture,
+        user_id = excluded.user_id,
         access_token = excluded.access_token,
         previous_access_token = excluded.previous_access_token,
         refresh_token = excluded.refresh_token,
-        scope = excluded.scope,
+        expires_at = excluded.expires_at,
         token_type = excluded.token_type,
-        access_token_expires_at = excluded.access_token_expires_at,
+        scope = excluded.scope,
         updated_at = excluded.updated_at
-    `)
+      `
+    )
     statement.run(
-      input.sessionId,
-      input.googleSub,
-      input.email,
-      input.name,
-      input.picture,
+      input.id,
+      input.userId,
       input.accessToken,
       input.previousAccessToken,
       input.refreshToken,
-      input.scope,
-      input.tokenType,
-      input.accessTokenExpiresAt,
+      input.expiresAt,
       createdAt,
+      input.tokenType,
+      input.scope,
       now
     )
 
@@ -87,31 +181,38 @@ export class AuthSessionStore {
     }
   }
 
-  async findBySessionId(sessionId: string): Promise<AuthSession | null> {
+  async findSessionById(sessionId: string): Promise<AuthSession | null> {
     const db = await this.getDb()
     const statement = db.prepare('SELECT * FROM auth_sessions WHERE session_id = ?')
     const row = statement.get(sessionId) as SessionRow | undefined
-    return row ? this.mapRow(row) : null
+    return row ? this.mapSessionRow(row) : null
   }
 
-  async findByRefreshToken(refreshToken: string): Promise<AuthSession | null> {
+  async findSessionByRefreshToken(refreshToken: string): Promise<AuthSession | null> {
     const db = await this.getDb()
     const statement = db.prepare('SELECT * FROM auth_sessions WHERE refresh_token = ?')
     const row = statement.get(refreshToken) as SessionRow | undefined
-    return row ? this.mapRow(row) : null
+    return row ? this.mapSessionRow(row) : null
   }
 
-  async findByAccessToken(accessToken: string): Promise<AuthSession | null> {
+  async findSessionByAccessToken(accessToken: string): Promise<AuthSession | null> {
     const db = await this.getDb()
     const statement = db.prepare(
       `
-      SELECT * FROM auth_sessions
+      SELECT *
+      FROM auth_sessions
       WHERE access_token = ? OR previous_access_token = ?
       LIMIT 1
       `
     )
     const row = statement.get(accessToken, accessToken) as SessionRow | undefined
-    return row ? this.mapRow(row) : null
+    return row ? this.mapSessionRow(row) : null
+  }
+
+  async deleteSessionById(sessionId: string): Promise<void> {
+    const db = await this.getDb()
+    const statement = db.prepare('DELETE FROM auth_sessions WHERE session_id = ?')
+    statement.run(sessionId)
   }
 
   private async getDb(): Promise<DatabaseSync> {
@@ -125,45 +226,243 @@ export class AuthSessionStore {
   private async initialize(): Promise<DatabaseSync> {
     await mkdir(dirname(this.dbPath), { recursive: true })
     const db = new DatabaseSync(this.dbPath)
+    db.exec('PRAGMA foreign_keys = ON;')
 
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_sessions (
-        session_id TEXT PRIMARY KEY,
-        google_sub TEXT NOT NULL,
+      CREATE TABLE IF NOT EXISTS users (
+        user_id TEXT PRIMARY KEY,
+        google_sub TEXT NOT NULL UNIQUE,
         email TEXT,
         name TEXT,
         picture TEXT,
+        created_at INTEGER NOT NULL,
+        last_login_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS auth_sessions (
+        session_id TEXT PRIMARY KEY,
+        user_id TEXT,
         access_token TEXT NOT NULL,
         previous_access_token TEXT,
         refresh_token TEXT NOT NULL UNIQUE,
+        expires_at INTEGER,
+        created_at INTEGER,
+        token_type TEXT,
         scope TEXT,
-        token_type TEXT NOT NULL,
-        access_token_expires_at INTEGER NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER,
+        FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
       );
+      CREATE INDEX IF NOT EXISTS idx_users_google_sub
+      ON users(google_sub);
       CREATE INDEX IF NOT EXISTS idx_auth_sessions_access_token
       ON auth_sessions(access_token);
+      CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id
+      ON auth_sessions(user_id);
     `)
+
+    this.ensureAuthSessionColumns(db)
+    this.migrateLegacySessions(db)
 
     return db
   }
 
-  private mapRow(row: SessionRow): AuthSession {
+  private ensureAuthSessionColumns(db: DatabaseSync): void {
+    const columns = this.getTableColumns(db, 'auth_sessions')
+    if (!columns.has('user_id')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN user_id TEXT;')
+    }
+    if (!columns.has('expires_at')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN expires_at INTEGER;')
+    }
+    if (!columns.has('created_at')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN created_at INTEGER;')
+    }
+    if (!columns.has('token_type')) {
+      db.exec("ALTER TABLE auth_sessions ADD COLUMN token_type TEXT DEFAULT 'Bearer';")
+    }
+    if (!columns.has('scope')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN scope TEXT;')
+    }
+    if (!columns.has('updated_at')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN updated_at INTEGER;')
+    }
+    if (!columns.has('previous_access_token')) {
+      db.exec('ALTER TABLE auth_sessions ADD COLUMN previous_access_token TEXT;')
+    }
+  }
+
+  private migrateLegacySessions(db: DatabaseSync): void {
+    const columns = this.getTableColumns(db, 'auth_sessions')
+    if (!columns.has('google_sub')) {
+      return
+    }
+
+    const seedUsers = db.prepare(
+      `
+      SELECT DISTINCT google_sub, email, name, picture
+      FROM auth_sessions
+      WHERE google_sub IS NOT NULL
+      `
+    )
+    const legacyUsers = seedUsers.all() as LegacySessionSeedRow[]
+    for (const user of legacyUsers) {
+      const existing = db
+        .prepare('SELECT user_id FROM users WHERE google_sub = ? LIMIT 1')
+        .get(user.google_sub) as { user_id: string } | undefined
+      if (!existing) {
+        const createdAt = Date.now()
+        this.insertUser(db, {
+          userId: randomUUID(),
+          googleSub: user.google_sub,
+          email: user.email,
+          name: user.name,
+          picture: user.picture,
+          createdAt,
+          lastLoginAt: createdAt
+        })
+      }
+    }
+
+    if (columns.has('access_token_expires_at')) {
+      db.exec(
+        `
+        UPDATE auth_sessions
+        SET expires_at = access_token_expires_at
+        WHERE expires_at IS NULL
+        `
+      )
+    }
+
+    db.exec(
+      `
+      UPDATE auth_sessions
+      SET user_id = (
+        SELECT user_id
+        FROM users
+        WHERE users.google_sub = auth_sessions.google_sub
+      )
+      WHERE user_id IS NULL AND google_sub IS NOT NULL
+      `
+    )
+
+    const now = Date.now()
+    db.prepare(
+      `
+      UPDATE auth_sessions
+      SET created_at = ?
+      WHERE created_at IS NULL
+      `
+    ).run(now)
+    db.prepare(
+      `
+      UPDATE auth_sessions
+      SET updated_at = ?
+      WHERE updated_at IS NULL
+      `
+    ).run(now)
+    db.prepare(
+      `
+      UPDATE auth_sessions
+      SET expires_at = ?
+      WHERE expires_at IS NULL
+      `
+    ).run(now + 3600_000)
+    db.prepare(
+      `
+      UPDATE auth_sessions
+      SET token_type = 'Bearer'
+      WHERE token_type IS NULL
+      `
+    ).run()
+
+    const syncLastLoginRows = db
+      .prepare(
+        `
+        SELECT google_sub, MAX(created_at) AS created_at
+        FROM auth_sessions
+        WHERE google_sub IS NOT NULL
+        GROUP BY google_sub
+        `
+      )
+      .all() as LegacyLastLoginRow[]
+    const syncLastLogin = db.prepare(
+      `
+      UPDATE users
+      SET last_login_at = CASE
+        WHEN last_login_at < ? THEN ?
+        ELSE last_login_at
+      END
+      WHERE google_sub = ?
+      `
+    )
+    for (const row of syncLastLoginRows) {
+      syncLastLogin.run(row.created_at, row.created_at, row.google_sub)
+    }
+  }
+
+  private getTableColumns(db: DatabaseSync, tableName: string): Set<string> {
+    const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>
+    return new Set(rows.map((row) => row.name))
+  }
+
+  private insertUser(
+    db: DatabaseSync,
+    user: {
+      userId: string
+      googleSub: string
+      email: string | null
+      name: string | null
+      picture: string | null
+      createdAt: number
+      lastLoginAt: number
+    }
+  ): void {
+    const statement = db.prepare(
+      `
+      INSERT INTO users (
+        user_id,
+        google_sub,
+        email,
+        name,
+        picture,
+        created_at,
+        last_login_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    statement.run(
+      user.userId,
+      user.googleSub,
+      user.email,
+      user.name,
+      user.picture,
+      user.createdAt,
+      user.lastLoginAt
+    )
+  }
+
+  private mapSessionRow(row: SessionRow): AuthSession {
     return {
-      sessionId: row.session_id,
-      googleSub: row.google_sub,
+      id: row.session_id,
+      userId: row.user_id,
+      accessToken: row.access_token,
+      refreshToken: row.refresh_token,
+      expiresAt: row.expires_at,
+      createdAt: row.created_at,
+      tokenType: row.token_type,
+      scope: row.scope,
+      previousAccessToken: row.previous_access_token,
+      updatedAt: row.updated_at
+    }
+  }
+
+  private mapUserRow(row: UserRow): User {
+    return {
+      id: row.user_id,
       email: row.email,
       name: row.name,
       picture: row.picture,
-      accessToken: row.access_token,
-      previousAccessToken: row.previous_access_token,
-      refreshToken: row.refresh_token,
-      scope: row.scope,
-      tokenType: row.token_type,
-      accessTokenExpiresAt: row.access_token_expires_at,
       createdAt: row.created_at,
-      updatedAt: row.updated_at
+      lastLoginAt: row.last_login_at
     }
   }
 }

--- a/services/api/src/auth/types.ts
+++ b/services/api/src/auth/types.ts
@@ -14,20 +14,32 @@ export type GoogleUserInfo = {
   picture?: string
 }
 
-export type AuthSession = {
-  sessionId: string
-  googleSub: string
+export type User = {
+  id: string
   email: string | null
   name: string | null
   picture: string | null
-  accessToken: string
-  previousAccessToken: string | null
-  refreshToken: string
-  scope: string | null
-  tokenType: string
-  accessTokenExpiresAt: number
   createdAt: number
+  lastLoginAt: number
+}
+
+export type AuthSession = {
+  id: string
+  userId: string
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  createdAt: number
+  tokenType: string
+  scope: string | null
+  previousAccessToken: string | null
   updatedAt: number
+}
+
+export type AuthenticatedContext = {
+  userId: string
+  sessionId: string
+  accessToken: string
 }
 
 export type AuthResult = {
@@ -37,12 +49,7 @@ export type AuthResult = {
   expiresIn: number
   scope: string | null
   tokenType: string
-  user: {
-    sub: string
-    email: string | null
-    name: string | null
-    picture: string | null
-  }
+  user: User
 }
 
 export type RefreshResult = {

--- a/services/api/src/middleware/rate-limit.ts
+++ b/services/api/src/middleware/rate-limit.ts
@@ -1,0 +1,55 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import { ApiError } from '../errors.js'
+
+type RateLimitOptions = {
+  limit: number
+  windowMs: number
+  errorCode: string
+  errorMessage: string
+  keyGenerator: (c: Context) => string
+}
+
+type Bucket = {
+  count: number
+  windowStart: number
+}
+
+const buckets = new Map<string, Bucket>()
+
+export function createRateLimitMiddleware(options: RateLimitOptions): MiddlewareHandler {
+  return async (c, next) => {
+    const key = options.keyGenerator(c)
+    const now = Date.now()
+    const bucket = buckets.get(key)
+    if (!bucket || now - bucket.windowStart >= options.windowMs) {
+      buckets.set(key, { count: 1, windowStart: now })
+      await next()
+      return
+    }
+
+    if (bucket.count >= options.limit) {
+      throw new ApiError(429, options.errorCode, options.errorMessage, false)
+    }
+
+    bucket.count += 1
+    await next()
+  }
+}
+
+export function getClientIp(c: Context): string {
+  const forwarded = c.req.header('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]?.trim() ?? 'unknown'
+  }
+
+  return (
+    c.req.header('x-real-ip') ??
+    c.req.header('cf-connecting-ip') ??
+    c.req.header('x-client-ip') ??
+    'unknown'
+  )
+}
+
+export function resetRateLimitStore(): void {
+  buckets.clear()
+}

--- a/services/api/src/routes/auth.ts
+++ b/services/api/src/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { getAuthService } from '../auth/index.js'
+import { parseBearerToken } from '../auth/middleware.js'
 import { ApiError } from '../errors.js'
 
 export const authRoutes = new Hono()
@@ -60,4 +61,12 @@ authRoutes.post('/token', async (c) => {
     },
     200
   )
+})
+
+authRoutes.post('/logout', async (c) => {
+  const authService = getAuthService()
+  const accessToken = parseBearerToken(c.req.header('authorization'))
+  await authService.logoutByAccessToken(accessToken)
+
+  return c.body(null, 204)
 })

--- a/services/api/src/routes/user.ts
+++ b/services/api/src/routes/user.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono'
-import { getAuthMiddleware } from '../auth/index.js'
+import { getAuthMiddleware, getAuthService } from '../auth/index.js'
 import { getAuthenticatedUserId } from '../auth/middleware.js'
 import { createRateLimitMiddleware } from '../middleware/rate-limit.js'
 
-export const protectedRoutes = new Hono()
+export const userRoutes = new Hono()
 const userRateLimitMiddleware = createRateLimitMiddleware({
   limit: 100,
   windowMs: 60_000,
@@ -12,8 +12,14 @@ const userRateLimitMiddleware = createRateLimitMiddleware({
   keyGenerator: (c) => `user:${getAuthenticatedUserId(c)}`
 })
 
-protectedRoutes.use('*', async (c, next) => {
+userRoutes.use('*', async (c, next) => {
   const middleware = getAuthMiddleware()
   return middleware(c, next)
 })
-protectedRoutes.use('*', userRateLimitMiddleware)
+userRoutes.use('*', userRateLimitMiddleware)
+
+userRoutes.get('/me', async (c) => {
+  const userId = getAuthenticatedUserId(c)
+  const user = await getAuthService().getUserById(userId)
+  return c.json(user, 200)
+})

--- a/services/api/src/types/node-sqlite.d.ts
+++ b/services/api/src/types/node-sqlite.d.ts
@@ -2,6 +2,7 @@ declare module 'node:sqlite' {
   class StatementSync {
     run(...params: unknown[]): unknown
     get(...params: unknown[]): unknown
+    all(...params: unknown[]): unknown[]
   }
 
   export class DatabaseSync {

--- a/services/api/test/auth.integration.test.ts
+++ b/services/api/test/auth.integration.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { app } from '../src/app.js'
 import { createAuthMiddleware } from '../src/auth/middleware.js'
 import { getAuthService, resetAuthForTests } from '../src/auth/index.js'
+import { resetRateLimitStore } from '../src/middleware/rate-limit.js'
 
 type JsonRecord = Record<string, unknown>
 
@@ -33,22 +34,26 @@ describe('Google OAuth auth endpoints', () => {
     process.env.GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
     process.env.GOOGLE_USERINFO_ENDPOINT = 'https://openidconnect.googleapis.com/v1/userinfo'
     resetAuthForTests()
+    resetRateLimitStore()
   })
 
   afterEach(async () => {
     globalThis.fetch = originalFetch
     resetAuthForTests()
+    resetRateLimitStore()
     await rm(testDbDir, { recursive: true, force: true })
   })
 
-  it('exchanges code for access and refresh tokens', async () => {
+  it('creates user on first login and reuses it on subsequent logins', async () => {
+    let tokenCounter = 0
     globalThis.fetch = vi.fn(async (input, init) => {
       const url = typeof input === 'string' ? input : input.toString()
       if (url.includes('/token')) {
+        tokenCounter += 1
         expect(init?.method).toBe('POST')
         return jsonResponse({
-          access_token: 'google-access-1',
-          refresh_token: 'google-refresh-1',
+          access_token: `google-access-${tokenCounter}`,
+          refresh_token: `google-refresh-${tokenCounter}`,
           expires_in: 3600,
           token_type: 'Bearer',
           scope: 'openid email profile'
@@ -63,21 +68,43 @@ describe('Google OAuth auth endpoints', () => {
       })
     }) as typeof fetch
 
-    const response = await app.request('/auth/google', {
+    const firstLogin = await app.request('/auth/google', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ code: 'valid-code' })
     })
-
-    expect(response.status).toBe(200)
-    const body = (await response.json()) as {
+    expect(firstLogin.status).toBe(200)
+    const firstBody = (await firstLogin.json()) as {
       sessionId: string
-      accessToken: string
-      refreshToken: string
+      user: {
+        id: string
+        createdAt: number
+        lastLoginAt: number
+      }
     }
-    expect(body.sessionId).toBeTruthy()
-    expect(body.accessToken).toBe('google-access-1')
-    expect(body.refreshToken).toBe('google-refresh-1')
+    expect(firstBody.sessionId).toBeTruthy()
+    expect(firstBody.user.id).toBeTruthy()
+
+    await new Promise((resolve) => setTimeout(resolve, 2))
+
+    const secondLogin = await app.request('/auth/google', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'valid-code-2' })
+    })
+    expect(secondLogin.status).toBe(200)
+    const secondBody = (await secondLogin.json()) as {
+      sessionId: string
+      user: {
+        id: string
+        createdAt: number
+        lastLoginAt: number
+      }
+    }
+    expect(secondBody.sessionId).toBeTruthy()
+    expect(secondBody.user.id).toBe(firstBody.user.id)
+    expect(secondBody.user.createdAt).toBe(firstBody.user.createdAt)
+    expect(secondBody.user.lastLoginAt).toBeGreaterThan(firstBody.user.lastLoginAt)
   })
 
   it('returns 401 when Google code is invalid', async () => {
@@ -168,6 +195,64 @@ describe('Google OAuth auth endpoints', () => {
     }
     expect(body.error.code).toBe('INVALID_REFRESH_TOKEN')
     expect(body.error.message).toContain('invalid or revoked')
+  })
+
+  it('invalidates current session on explicit logout', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/token')) {
+        const body = String(init?.body ?? '')
+        if (body.includes('grant_type=authorization_code')) {
+          return jsonResponse({
+            access_token: 'google-access-logout',
+            refresh_token: 'google-refresh-logout',
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'openid email profile'
+          })
+        }
+
+        return jsonResponse({
+          access_token: 'google-access-refreshed-logout',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'openid email profile'
+        })
+      }
+
+      return jsonResponse({
+        sub: 'google-sub-logout',
+        email: 'logout@example.com'
+      })
+    }) as typeof fetch
+
+    const loginResponse = await app.request('/auth/google', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'valid-code' })
+    })
+    const loginBody = (await loginResponse.json()) as { accessToken: string }
+
+    const logoutResponse = await app.request('/auth/logout', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${loginBody.accessToken}`
+      }
+    })
+    expect(logoutResponse.status).toBe(204)
+
+    const protectedResponse = await app.request('/user/me', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${loginBody.accessToken}`
+      }
+    })
+    expect(protectedResponse.status).toBe(401)
+    const body = (await protectedResponse.json()) as {
+      error: { code: string; message: string; retryable: boolean }
+    }
+    expect(body.error.code).toBe('INVALID_ACCESS_TOKEN')
+    expect(body.error.retryable).toBe(false)
   })
 
   it('automatically refreshes expired access token in auth middleware', async () => {

--- a/services/api/test/user-rate-limit.integration.test.ts
+++ b/services/api/test/user-rate-limit.integration.test.ts
@@ -1,0 +1,336 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { app } from '../src/app.js'
+import { resetAuthForTests } from '../src/auth/index.js'
+import { resetRateLimitStore } from '../src/middleware/rate-limit.js'
+
+type JsonRecord = Record<string, unknown>
+
+function jsonResponse(body: JsonRecord, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json'
+    }
+  })
+}
+
+describe('user profile and rate limiting', () => {
+  const originalFetch = globalThis.fetch
+  let testDbDir = ''
+
+  beforeEach(async () => {
+    testDbDir = await mkdtemp(join(tmpdir(), 'aura-user-'))
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id'
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret'
+    process.env.GOOGLE_REDIRECT_URI = 'aura://oauth2redirect/google'
+    process.env.GOOGLE_OAUTH_SCOPES = 'openid email profile'
+    process.env.AUTH_DB_PATH = join(testDbDir, 'auth.db')
+    process.env.AUTH_ACCESS_TOKEN_EXPIRY_SKEW_MS = '0'
+    process.env.GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+    process.env.GOOGLE_USERINFO_ENDPOINT = 'https://openidconnect.googleapis.com/v1/userinfo'
+    resetAuthForTests()
+    resetRateLimitStore()
+  })
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    resetAuthForTests()
+    resetRateLimitStore()
+    await rm(testDbDir, { recursive: true, force: true })
+  })
+
+  async function loginWithIdentity(options: {
+    code: string
+    sub: string
+    email: string
+    name?: string
+    setMock?: boolean
+  }): Promise<{ accessToken: string; userId: string }> {
+    if (options.setMock ?? true) {
+      globalThis.fetch = vi.fn(async (input) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes('/token')) {
+          return jsonResponse({
+            access_token: `google-access-${options.code}`,
+            refresh_token: `google-refresh-${options.code}`,
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'openid email profile'
+          })
+        }
+
+        return jsonResponse({
+          sub: options.sub,
+          email: options.email,
+          name: options.name ?? options.email
+        })
+      }) as typeof fetch
+    }
+
+    const loginResponse = await app.request('/auth/google', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: options.code })
+    })
+    if (loginResponse.status !== 200) {
+      const errorBody = await loginResponse.text()
+      throw new Error(`login ${options.code} failed (${loginResponse.status}): ${errorBody}`)
+    }
+
+    const loginBody = (await loginResponse.json()) as {
+      accessToken: string
+      user: { id: string }
+    }
+    return { accessToken: loginBody.accessToken, userId: loginBody.user.id }
+  }
+
+  it('returns authenticated user profile from /user/me', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/token')) {
+        expect(init?.method).toBe('POST')
+        return jsonResponse({
+          access_token: 'google-access-profile',
+          refresh_token: 'google-refresh-profile',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'openid email profile'
+        })
+      }
+
+      return jsonResponse({
+        sub: 'google-sub-profile',
+        email: 'profile@example.com',
+        name: 'Profile User',
+        picture: 'https://example.com/profile.png'
+      })
+    }) as typeof fetch
+
+    const loginResponse = await app.request('/auth/google', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'valid-code' })
+    })
+    expect(loginResponse.status).toBe(200)
+    const loginBody = (await loginResponse.json()) as {
+      accessToken: string
+      user: { id: string }
+    }
+
+    const meResponse = await app.request('/user/me', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${loginBody.accessToken}`
+      }
+    })
+    expect(meResponse.status).toBe(200)
+    const meBody = (await meResponse.json()) as {
+      id: string
+      email: string | null
+      name: string | null
+      picture: string | null
+      createdAt: number
+      lastLoginAt: number
+    }
+    expect(meBody.id).toBe(loginBody.user.id)
+    expect(meBody.email).toBe('profile@example.com')
+    expect(meBody.name).toBe('Profile User')
+    expect(meBody.picture).toBe('https://example.com/profile.png')
+    expect(meBody.createdAt).toBeTypeOf('number')
+    expect(meBody.lastLoginAt).toBeTypeOf('number')
+  })
+
+  it('rate limits auth endpoints to 20 requests per minute by client IP', async () => {
+    let lastStatus = 0
+    for (let index = 0; index < 20; index += 1) {
+      const response = await app.request('/auth/token', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-for': '203.0.113.10'
+        },
+        body: JSON.stringify({ refreshToken: 'missing-refresh-token' })
+      })
+      lastStatus = response.status
+    }
+    expect(lastStatus).toBe(401)
+
+    const limitedResponse = await app.request('/auth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.10'
+      },
+      body: JSON.stringify({ refreshToken: 'missing-refresh-token' })
+    })
+    expect(limitedResponse.status).toBe(429)
+    const body = (await limitedResponse.json()) as {
+      error: { code: string; message: string; retryable: boolean }
+    }
+    expect(body.error.code).toBe('RATE_LIMITED')
+    expect(body.error.retryable).toBe(false)
+  })
+
+  it('keeps auth rate limit buckets isolated per client IP', async () => {
+    for (let index = 0; index < 20; index += 1) {
+      const response = await app.request('/auth/token', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-for': '203.0.113.20'
+        },
+        body: JSON.stringify({ refreshToken: 'missing-refresh-token' })
+      })
+      expect(response.status).toBe(401)
+    }
+
+    const ipOneLimitedResponse = await app.request('/auth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.20'
+      },
+      body: JSON.stringify({ refreshToken: 'missing-refresh-token' })
+    })
+    expect(ipOneLimitedResponse.status).toBe(429)
+
+    const ipTwoResponse = await app.request('/auth/token', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.21'
+      },
+      body: JSON.stringify({ refreshToken: 'missing-refresh-token' })
+    })
+    expect(ipTwoResponse.status).toBe(401)
+  })
+
+  it('rate limits general authenticated endpoints to 100 requests per minute by user', async () => {
+    const login = await loginWithIdentity({
+      code: 'valid-code',
+      sub: 'google-sub-rate-limit',
+      email: 'rate-limit@example.com'
+    })
+
+    let okStatus = 0
+    for (let index = 0; index < 100; index += 1) {
+      const response = await app.request('/user/me', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${login.accessToken}`
+        }
+      })
+      okStatus = response.status
+    }
+    expect(okStatus).toBe(200)
+
+    const limitedResponse = await app.request('/user/me', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${login.accessToken}`
+      }
+    })
+    expect(limitedResponse.status).toBe(429)
+    const body = (await limitedResponse.json()) as {
+      error: { code: string; message: string; retryable: boolean }
+    }
+    expect(body.error.code).toBe('RATE_LIMITED')
+    expect(body.error.retryable).toBe(false)
+  })
+
+  it('keeps authenticated rate limit buckets isolated per user', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/token')) {
+        const body = String(init?.body ?? '')
+        if (body.includes('code=user-one-code')) {
+          return jsonResponse({
+            access_token: 'google-access-user-one',
+            refresh_token: 'google-refresh-user-one',
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'openid email profile'
+          })
+        }
+
+        return jsonResponse({
+          access_token: 'google-access-user-two',
+          refresh_token: 'google-refresh-user-two',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'openid email profile'
+        })
+      }
+
+      const initHeaders =
+        init?.headers && typeof init.headers === 'object'
+          ? new Headers(init.headers as HeadersInit)
+          : new Headers()
+      const authHeader = initHeaders.get('authorization') ?? ''
+      if (authHeader.includes('google-access-user-one')) {
+        return jsonResponse({
+          sub: 'google-sub-user-one',
+          email: 'user-one@example.com'
+        })
+      }
+
+      return jsonResponse({
+        sub: 'google-sub-user-two',
+        email: 'user-two@example.com'
+      })
+    }) as typeof fetch
+
+    const userOne = await loginWithIdentity({
+      code: 'user-one-code',
+      sub: 'google-sub-user-one',
+      email: 'user-one@example.com',
+      setMock: false
+    })
+    const userTwo = await loginWithIdentity({
+      code: 'user-two-code',
+      sub: 'google-sub-user-two',
+      email: 'user-two@example.com',
+      setMock: false
+    })
+    expect(userOne.userId).not.toBe(userTwo.userId)
+
+    for (let index = 0; index < 100; index += 1) {
+      const response = await app.request('/user/me', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${userOne.accessToken}`
+        }
+      })
+      expect(response.status).toBe(200)
+    }
+
+    const userOneLimited = await app.request('/user/me', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${userOne.accessToken}`
+      }
+    })
+    expect(userOneLimited.status).toBe(429)
+
+    const userTwoResponse = await app.request('/user/me', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${userTwo.accessToken}`
+      }
+    })
+    expect(userTwoResponse.status).toBe(200)
+  })
+
+  it('returns standardized unauthorized error for /user/me without token', async () => {
+    const response = await app.request('/user/me', { method: 'GET' })
+    expect(response.status).toBe(401)
+    const body = (await response.json()) as {
+      error: { code: string; message: string; retryable: boolean }
+    }
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(body.error.retryable).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add first-class `users` and `auth_sessions` handling with user-linked sessions and migration-safe startup logic
- implement `POST /auth/logout`, `GET /user/me`, and auth middleware context updates to attach authenticated `userId`
- add per-IP auth rate limiting (20/min), per-user endpoint rate limiting (100/min), schema docs, and stronger integration tests

## Test plan
- [x] Run `pnpm --filter api test`
- [x] Verify login create/reuse behavior via integration tests
- [x] Verify logout invalidates current session
- [x] Verify auth/user rate-limit boundary and isolation behavior

Made with [Cursor](https://cursor.com)