### PR TITLE
feat(mobile): auth login and signup UI

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -1,0 +1,118 @@
+import { AuthHeaderBrand } from '@/components/auth/auth-header-brand';
+import { AuthScreenShell } from '@/components/auth/auth-screen-shell';
+import { AuthSocialProviderRow } from '@/components/auth/auth-social-provider-row';
+import { AuraButton } from '@/components/ui/aura-button';
+import { AuraOrDivider } from '@/components/ui/aura-or-divider';
+import { AuraTextField } from '@/components/ui/aura-text-field';
+import { Icon } from '@/components/ui/icon';
+import { Text } from '@/components/ui/text';
+import { rgbaWhite } from '@/lib/raw-colors';
+import { router, type Href } from 'expo-router';
+import { Eye, EyeOff, Lock, Mail } from 'lucide-react-native';
+import { useState } from 'react';
+import { Pressable, View } from 'react-native';
+
+const LABEL_CLASS =
+  'text-[11px] font-bold uppercase tracking-[0.05em] text-muted-foreground';
+
+export default function LoginScreen() {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  return (
+    <View className="flex-1">
+      <AuthHeaderBrand />
+
+      <AuthScreenShell
+        footer={
+          <View className="mt-10 w-full items-center px-2">
+            <Text
+              className="w-full text-center text-sm text-muted-foreground"
+              style={{ fontFamily: 'Manrope_500Medium' }}>
+              Don&apos;t have an account?{' '}
+              <Text
+                accessibilityRole="link"
+                accessibilityLabel="Join AURA"
+                className="text-primary font-bold"
+                onPress={() => router.push('/signup' as Href)}
+                style={{ fontFamily: 'Manrope_700Bold' }}>
+                Join AURA
+              </Text>
+            </Text>
+          </View>
+        }>
+        <View className="items-center gap-2">
+          <Text
+            className="text-center text-[3.25rem] font-extrabold leading-tight tracking-tight text-foreground"
+            style={{ fontFamily: 'Manrope_800ExtraBold' }}>
+            Welcome{'\n'}Back
+          </Text>
+          <Text
+            className="text-muted-foreground max-w-sm text-center text-lg leading-6"
+            style={{ fontFamily: 'Manrope_500Medium' }}>
+            Enter your details to access your sanctuary.
+          </Text>
+        </View>
+
+        <View className="gap-5 pt-2">
+          <AuraTextField
+            label="Email Address"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={Mail}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder="hello@aura.io"
+            className="h-14 rounded-full border-border/40 bg-card"
+          />
+          <AuraTextField
+            label="Password"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={Lock}
+            placeholder="••••••••"
+            secureTextEntry={!passwordVisible}
+            className="h-14 rounded-full border-border/40 bg-card"
+            trailing={
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={passwordVisible ? 'Hide password' : 'Show password'}
+                hitSlop={8}
+                onPress={() => setPasswordVisible((v) => !v)}
+                android_ripple={{ color: rgbaWhite(0.12) }}
+                className="rounded-full p-1.5 active:opacity-70">
+                <Icon
+                  as={passwordVisible ? Eye : EyeOff}
+                  size={20}
+                  className="text-muted-foreground"
+                />
+              </Pressable>
+            }
+          />
+          <View className="flex-row justify-end">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Recover password"
+              android_ripple={{ color: rgbaWhite(0.12) }}
+              hitSlop={8}>
+              <Text
+                className="text-secondary text-sm font-semibold"
+                style={{ fontFamily: 'Manrope_600SemiBold' }}>
+                Recover Password?
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <AuraButton
+          label="Sign In"
+          className="h-14 w-full rounded-full shadow-sm shadow-primary/30"
+          onPress={() => undefined}
+          accessibilityLabel="Sign in"
+        />
+
+        <AuraOrDivider label="Or continue with" className="my-2" />
+
+        <AuthSocialProviderRow />
+      </AuthScreenShell>
+    </View>
+  );
+}

--- a/apps/mobile/app/signup.tsx
+++ b/apps/mobile/app/signup.tsx
@@ -1,0 +1,138 @@
+import { AuthHeaderBrand } from '@/components/auth/auth-header-brand';
+import { AuthScreenShell } from '@/components/auth/auth-screen-shell';
+import { AuthSocialProviderRow } from '@/components/auth/auth-social-provider-row';
+import { AuraButton } from '@/components/ui/aura-button';
+import { AuraOrDivider } from '@/components/ui/aura-or-divider';
+import { AuraTextField } from '@/components/ui/aura-text-field';
+import { Icon } from '@/components/ui/icon';
+import { Text } from '@/components/ui/text';
+import { rgbaWhite } from '@/lib/raw-colors';
+import { router, type Href } from 'expo-router';
+import { Eye, EyeOff, Lock, Mail, User } from 'lucide-react-native';
+import { useState } from 'react';
+import { Pressable, View } from 'react-native';
+
+const LABEL_CLASS =
+  'text-[11px] font-bold uppercase tracking-[0.05em] text-muted-foreground';
+
+export default function SignupScreen() {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [confirmVisible, setConfirmVisible] = useState(false);
+
+  return (
+    <View className="flex-1">
+      <AuthHeaderBrand />
+
+      <AuthScreenShell
+        footer={
+          <View className="mt-10 w-full items-center px-2">
+            <Text
+              className="w-full text-center text-sm text-muted-foreground"
+              style={{ fontFamily: 'Manrope_500Medium' }}>
+              Already have an account?{' '}
+              <Text
+                accessibilityRole="link"
+                accessibilityLabel="Sign in"
+                className="text-primary font-bold"
+                onPress={() => router.push('/login' as Href)}
+                style={{ fontFamily: 'Manrope_700Bold' }}>
+                Sign in
+              </Text>
+            </Text>
+          </View>
+        }>
+        <View className="items-center gap-2">
+          <Text
+            className="text-center text-[2.75rem] font-extrabold leading-tight tracking-tight text-foreground"
+            style={{ fontFamily: 'Manrope_800ExtraBold' }}>
+            Join AURA
+          </Text>
+          <Text
+            className="text-muted-foreground max-w-sm text-center text-lg leading-6"
+            style={{ fontFamily: 'Manrope_500Medium' }}>
+            Create your sanctuary in a few steps.
+          </Text>
+        </View>
+
+        <View className="gap-5 pt-2">
+          <AuraTextField
+            label="Display Name"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={User}
+            autoCapitalize="words"
+            autoCorrect
+            placeholder="Your name"
+            className="h-14 rounded-full border-border/40 bg-card"
+          />
+          <AuraTextField
+            label="Email Address"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={Mail}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder="hello@aura.io"
+            className="h-14 rounded-full border-border/40 bg-card"
+          />
+          <AuraTextField
+            label="Password"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={Lock}
+            placeholder="••••••••"
+            secureTextEntry={!passwordVisible}
+            className="h-14 rounded-full border-border/40 bg-card"
+            trailing={
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={passwordVisible ? 'Hide password' : 'Show password'}
+                hitSlop={8}
+                onPress={() => setPasswordVisible((v) => !v)}
+                android_ripple={{ color: rgbaWhite(0.12) }}
+                className="rounded-full p-1.5 active:opacity-70">
+                <Icon
+                  as={passwordVisible ? Eye : EyeOff}
+                  size={20}
+                  className="text-muted-foreground"
+                />
+              </Pressable>
+            }
+          />
+          <AuraTextField
+            label="Confirm Password"
+            labelClassName={LABEL_CLASS}
+            leadingIcon={Lock}
+            placeholder="••••••••"
+            secureTextEntry={!confirmVisible}
+            className="h-14 rounded-full border-border/40 bg-card"
+            trailing={
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={confirmVisible ? 'Hide confirm password' : 'Show confirm password'}
+                hitSlop={8}
+                onPress={() => setConfirmVisible((v) => !v)}
+                android_ripple={{ color: rgbaWhite(0.12) }}
+                className="rounded-full p-1.5 active:opacity-70">
+                <Icon
+                  as={confirmVisible ? Eye : EyeOff}
+                  size={20}
+                  className="text-muted-foreground"
+                />
+              </Pressable>
+            }
+          />
+        </View>
+
+        <AuraButton
+          label="Create account"
+          className="h-14 w-full rounded-full shadow-sm shadow-primary/30"
+          onPress={() => undefined}
+          accessibilityLabel="Create account"
+        />
+
+        <AuraOrDivider label="Or continue with" className="my-2" />
+
+        <AuthSocialProviderRow />
+      </AuthScreenShell>
+    </View>
+  );
+}

--- a/apps/mobile/app/welcome.tsx
+++ b/apps/mobile/app/welcome.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/lib/raw-colors';
 import { THEME } from '@/lib/theme';
 import { LinearGradient } from 'expo-linear-gradient';
-import { router } from 'expo-router';
+import { router, type Href } from 'expo-router';
 import { useRef } from 'react';
 import {
   Image,
@@ -165,11 +165,11 @@ export default function WelcomeScreen() {
         showsVerticalScrollIndicator={false}>
         <View className="gap-8">
           <View className="gap-5">
-            <View className="self-start rounded-full border border-secondary/25 bg-secondary/10 px-3.5 py-2">
+            <View className="border-secondary/25 bg-secondary/10 self-start rounded-full border px-3.5 py-2">
               <View className="flex-row items-center gap-2">
                 <Sparkles size={14} color={THEME.dark.secondary} />
                 <Text
-                  className="text-[11px] font-bold uppercase tracking-[0.22em] text-secondary"
+                  className="text-secondary text-[11px] font-bold uppercase tracking-[0.22em]"
                   style={{ fontFamily: 'Manrope_700Bold' }}>
                   Neural Synchronized Presence
                 </Text>
@@ -184,7 +184,7 @@ export default function WelcomeScreen() {
               </GradientText>
             </View>
             <Text
-              className="text-[17px] leading-[26px] text-muted-foreground"
+              className="text-muted-foreground text-[17px] leading-[26px]"
               style={{ fontFamily: 'Manrope_500Medium' }}>
               Transcend traditional interaction. Aura adapts to your cognitive patterns, evolving
               alongside your digital consciousness in an ethereal flow of insight.
@@ -192,9 +192,9 @@ export default function WelcomeScreen() {
             <View className="mt-1 flex-row flex-wrap gap-x-5 gap-y-2 border-t border-white/[0.06] pt-5">
               {['Voice-first', 'Private by design', 'On-device aware'].map((label) => (
                 <View key={label} className="flex-row items-center gap-2">
-                  <View className="h-1.5 w-1.5 rounded-full bg-primary" />
+                  <View className="bg-primary h-1.5 w-1.5 rounded-full" />
                   <Text
-                    className="text-xs font-semibold tracking-wide text-muted-foreground"
+                    className="text-muted-foreground text-xs font-semibold tracking-wide"
                     style={{ fontFamily: 'Manrope_600SemiBold' }}>
                     {label}
                   </Text>
@@ -206,12 +206,12 @@ export default function WelcomeScreen() {
           <View className="flex-col gap-3 pt-1">
             <Pressable
               accessibilityRole="button"
-              onPress={() => router.replace('/(tabs)')}
+              onPress={() => router.push('/login' as Href)}
               android_ripple={{ color: RIPPLE.onPrimary }}
               className="w-full flex-row items-center justify-center gap-1 rounded-full py-[18px] active:opacity-90"
               style={[{ backgroundColor: THEME.dark.primary }, PRIMARY_CTA_SHADOW]}>
               <Text
-                className="text-base font-bold text-primary-foreground"
+                className="text-primary-foreground text-base font-bold"
                 style={{ fontFamily: 'Manrope_700Bold' }}>
                 Get Started
               </Text>
@@ -223,7 +223,7 @@ export default function WelcomeScreen() {
               android_ripple={{ color: rgbaWhite(0.12) }}
               className="w-full items-center rounded-full border border-white/[0.14] bg-white/[0.05] py-[18px] active:opacity-90">
               <Text
-                className="text-base font-bold text-foreground"
+                className="text-foreground text-base font-bold"
                 style={{ fontFamily: 'Manrope_700Bold' }}>
                 Learn More
               </Text>
@@ -243,7 +243,7 @@ export default function WelcomeScreen() {
               end={{ x: 1, y: 1 }}
               style={StyleSheet.absoluteFillObject}
             />
-            <View className="absolute inset-[1px] overflow-hidden rounded-[31px] border border-white/[0.1] bg-card">
+            <View className="bg-card absolute inset-[1px] overflow-hidden rounded-[31px] border border-white/[0.1]">
               <Image source={HERO_IMAGE} className="h-full w-full" resizeMode="cover" />
               <LinearGradient
                 colors={[
@@ -267,7 +267,7 @@ export default function WelcomeScreen() {
                   Adaptive Oracle
                 </Text>
                 <Text
-                  className="mt-1 text-sm text-muted-foreground"
+                  className="text-muted-foreground mt-1 text-sm"
                   style={{ fontFamily: 'Manrope_500Medium' }}>
                   Real-time neural pattern mapping
                 </Text>
@@ -280,7 +280,7 @@ export default function WelcomeScreen() {
               className="relative overflow-hidden rounded-[28px] border border-white/[0.1] bg-white/[0.035] p-7"
               style={CARD_SHADOW}>
               <View className="flex-row gap-5">
-                <View className="h-14 w-14 items-center justify-center rounded-2xl border border-secondary/20 bg-secondary/10">
+                <View className="border-secondary/20 bg-secondary/10 h-14 w-14 items-center justify-center rounded-2xl border">
                   <Icon as={Network} size={26} color={THEME.dark.secondary} />
                 </View>
                 <View className="flex-1 gap-2.5">
@@ -290,7 +290,7 @@ export default function WelcomeScreen() {
                     Neural Sync
                   </Text>
                   <Text
-                    className="text-sm leading-[22px] text-muted-foreground"
+                    className="text-muted-foreground text-sm leading-[22px]"
                     style={{ fontFamily: 'Manrope_500Medium' }}>
                     Seamless integration between your device ecosystem and our distributed
                     intelligence core.
@@ -302,7 +302,7 @@ export default function WelcomeScreen() {
               className="relative overflow-hidden rounded-[28px] border border-white/[0.1] bg-white/[0.035] p-7"
               style={CARD_SHADOW}>
               <View className="flex-row gap-5">
-                <View className="h-14 w-14 items-center justify-center rounded-2xl border border-tertiary/25 bg-tertiary/10">
+                <View className="border-tertiary/25 bg-tertiary/10 h-14 w-14 items-center justify-center rounded-2xl border">
                   <Icon as={Lock} size={26} color={THEME.dark.tertiary} />
                 </View>
                 <View className="flex-1 gap-2.5">
@@ -312,7 +312,7 @@ export default function WelcomeScreen() {
                     Vault Secure
                   </Text>
                   <Text
-                    className="text-sm leading-[22px] text-muted-foreground"
+                    className="text-muted-foreground text-sm leading-[22px]"
                     style={{ fontFamily: 'Manrope_500Medium' }}>
                     Quantum-resistant encryption layers ensuring your cognitive data remains yours
                     alone.

--- a/apps/mobile/components/auth/auth-header-brand.tsx
+++ b/apps/mobile/components/auth/auth-header-brand.tsx
@@ -1,0 +1,28 @@
+import { AuraLogo } from '@/components/brand/aura-logo';
+import { AppTopBar } from '@/components/common';
+import { GradientText } from '@/components/welcome/gradient-text';
+import { THEME } from '@/lib/theme';
+import { StyleSheet, View } from 'react-native';
+
+/**
+ * App top bar: raster mark + “AURA” wordmark in one row, centered on the full bar
+ * (avoids skew from `justify-between` + empty trailing slot).
+ */
+export function AuthHeaderBrand() {
+  return (
+    <AppTopBar
+      backgroundColor={THEME.dark.surfaceDim}
+      leading={
+        <View
+          pointerEvents="box-none"
+          style={StyleSheet.absoluteFillObject}
+          className="flex-row items-center justify-center gap-2">
+          <AuraLogo width={36} height={32} />
+          <GradientText variant="aura" className="text-2xl font-black tracking-tighter">
+            AURA
+          </GradientText>
+        </View>
+      }
+    />
+  );
+}

--- a/apps/mobile/components/auth/auth-screen-shell.tsx
+++ b/apps/mobile/components/auth/auth-screen-shell.tsx
@@ -1,0 +1,104 @@
+import { APP_TOP_BAR_INNER_HEIGHT } from '@/components/common';
+import { rgbaBlack, WELCOME } from '@/lib/raw-colors';
+import { THEME } from '@/lib/theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import type { PropsWithChildren, ReactNode } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Svg, { Defs, RadialGradient, Rect, Stop } from 'react-native-svg';
+
+const BG_BASE = THEME.dark.surfaceDim;
+
+const HEADER_BOTTOM_GAP = 24;
+
+function AuthAmbientBackground({ width, height }: { width: number; height: number }) {
+  const cx = width * 0.12;
+  const cy = height * 0.06;
+  const r = Math.max(width, height) * 1.05;
+
+  const cxAccent = width * 0.82;
+  const cyAccent = height * 0.42;
+  const rAccent = Math.max(width, height) * 0.72;
+
+  return (
+    <Svg
+      width={width}
+      height={height}
+      style={StyleSheet.absoluteFillObject}
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants">
+      <Defs>
+        <RadialGradient id="authRadialGlow" cx={cx} cy={cy} r={r} gradientUnits="userSpaceOnUse">
+          <Stop offset="0" stopColor={WELCOME.radialGlowStart} stopOpacity="1" />
+          <Stop offset="0.38" stopColor={WELCOME.radialGlowMid} stopOpacity="1" />
+          <Stop offset="1" stopColor={BG_BASE} stopOpacity="1" />
+        </RadialGradient>
+        <RadialGradient
+          id="authRadialAccent"
+          cx={cxAccent}
+          cy={cyAccent}
+          r={rAccent}
+          gradientUnits="userSpaceOnUse">
+          <Stop offset="0" stopColor={WELCOME.radialAccentStart} stopOpacity="0.55" />
+          <Stop offset="0.42" stopColor={WELCOME.radialAccentMid} stopOpacity="0.22" />
+          <Stop offset="1" stopColor={BG_BASE} stopOpacity="0" />
+        </RadialGradient>
+      </Defs>
+      <Rect x={0} y={0} width={width} height={height} fill="url(#authRadialGlow)" />
+      <Rect x={0} y={0} width={width} height={height} fill="url(#authRadialAccent)" />
+    </Svg>
+  );
+}
+
+type AuthScreenShellProps = PropsWithChildren<{
+  footer?: ReactNode;
+}>;
+
+/**
+ * Dark auth layout: ambient background, keyboard-aware scroll, safe-area padding below the app top bar.
+ * Render {@link AppTopBar} as a sibling above this shell (same pattern as welcome).
+ */
+export function AuthScreenShell({ children, footer }: AuthScreenShellProps) {
+  const insets = useSafeAreaInsets();
+  const { width, height } = useWindowDimensions();
+
+  const topPad = insets.top;
+  const bottomPad = Math.max(insets.bottom, 16);
+  const contentTop = topPad + APP_TOP_BAR_INNER_HEIGHT + HEADER_BOTTOM_GAP;
+
+  return (
+    <View className="flex-1" style={{ backgroundColor: BG_BASE }}>
+      <AuthAmbientBackground width={width} height={height} />
+      <LinearGradient
+        pointerEvents="none"
+        colors={[rgbaBlack(0.35), 'transparent']}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={0}>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{
+            paddingTop: contentTop,
+            paddingBottom: bottomPad + 32,
+            paddingHorizontal: 24,
+            flexGrow: 1,
+          }}>
+          <View className="gap-6">{children}</View>
+          {footer}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}

--- a/apps/mobile/components/auth/auth-social-provider-row.tsx
+++ b/apps/mobile/components/auth/auth-social-provider-row.tsx
@@ -1,0 +1,34 @@
+import { RIPPLE } from '@/lib/raw-colors';
+import { THEME } from '@/lib/theme';
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import { useColorScheme } from 'nativewind';
+import { Pressable, View } from 'react-native';
+
+const PROVIDERS = [
+  { id: 'google', icon: 'google' as const, label: 'Continue with Google' },
+  { id: 'apple', icon: 'apple' as const, label: 'Continue with Apple' },
+] as const;
+
+/**
+ * UI-only OAuth affordances (Google + Apple). No SDK wiring.
+ */
+export function AuthSocialProviderRow() {
+  const { colorScheme } = useColorScheme();
+  const scheme = colorScheme ?? 'dark';
+  const iconColor = THEME[scheme].mutedForeground;
+
+  return (
+    <View className="flex-row justify-center gap-4">
+      {PROVIDERS.map(({ id, icon, label }) => (
+        <Pressable
+          key={id}
+          accessibilityRole="button"
+          accessibilityLabel={label}
+          android_ripple={{ color: RIPPLE.onPrimary }}
+          className="h-14 max-w-[48%] flex-1 items-center justify-center rounded-full border border-border/40 bg-card active:opacity-80">
+          <FontAwesome5 name={icon} brand size={22} color={iconColor} />
+        </Pressable>
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/components/auth/index.ts
+++ b/apps/mobile/components/auth/index.ts
@@ -1,0 +1,3 @@
+export { AuthHeaderBrand } from '@/components/auth/auth-header-brand';
+export { AuthScreenShell } from '@/components/auth/auth-screen-shell';
+export { AuthSocialProviderRow } from '@/components/auth/auth-social-provider-row';

--- a/apps/mobile/components/brand/aura-logo.tsx
+++ b/apps/mobile/components/brand/aura-logo.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Image, type ImageProps, type ImageStyle, type StyleProp } from 'react-native';
+
+const LOGO = require('@/assets/images/aura_logo.png');
+
+export type AuraLogoProps = Omit<ImageProps, 'source'> & {
+  /** Default width in logical pixels. */
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Raster AURA mark from `assets/images/aura_logo.png`. Pass `style` or `width`/`height` to scale.
+ */
+export function AuraLogo({
+  width = 36,
+  height = 32,
+  style,
+  resizeMode = 'contain',
+  accessibilityLabel = 'AURA',
+  accessibilityRole = 'image',
+  ...rest
+}: AuraLogoProps) {
+  const resolvedStyle: StyleProp<ImageStyle> = [{ width, height }, style];
+
+  return (
+    <Image
+      source={LOGO}
+      resizeMode={resizeMode}
+      accessibilityRole={accessibilityRole}
+      accessibilityLabel={accessibilityLabel}
+      style={resolvedStyle}
+      {...rest}
+    />
+  );
+}

--- a/apps/mobile/components/brand/index.ts
+++ b/apps/mobile/components/brand/index.ts
@@ -1,0 +1,1 @@
+export { AuraLogo, type AuraLogoProps } from '@/components/brand/aura-logo';

--- a/apps/mobile/components/common/app-top-bar.tsx
+++ b/apps/mobile/components/common/app-top-bar.tsx
@@ -50,7 +50,7 @@ export function AppTopBar({
         locations={[0, 1]}
         style={styles.topSheen}
       />
-      <View className="h-20 flex-row items-center justify-between">
+      <View className="relative h-20 flex-row items-center justify-between">
         {leading ?? <View />}
         {trailing ?? <View />}
       </View>

--- a/apps/mobile/components/ui/aura-or-divider.tsx
+++ b/apps/mobile/components/ui/aura-or-divider.tsx
@@ -1,0 +1,23 @@
+import { Text } from '@/components/ui/text';
+import { cn } from '@/lib/utils';
+import { View } from 'react-native';
+
+type AuraOrDividerProps = {
+  /** Center label, e.g. "Or continue with" */
+  label: string;
+  className?: string;
+};
+
+export function AuraOrDivider({ label, className }: AuraOrDividerProps) {
+  return (
+    <View className={cn('flex-row items-center gap-3', className)}>
+      <View className="h-px flex-1 bg-border/40" />
+      <Text
+        className="text-muted-foreground text-[11px] font-semibold uppercase tracking-[0.22em]"
+        style={{ fontFamily: 'Manrope_600SemiBold' }}>
+        {label}
+      </Text>
+      <View className="h-px flex-1 bg-border/40" />
+    </View>
+  );
+}

--- a/apps/mobile/components/ui/aura-text-field.tsx
+++ b/apps/mobile/components/ui/aura-text-field.tsx
@@ -11,6 +11,9 @@ type AuraTextFieldProps = React.ComponentProps<typeof Input> & {
   helperText?: string;
   errorText?: string;
   leadingIcon?: LucideIcon;
+  /** Renders inside the field on the right (e.g. password visibility toggle). */
+  trailing?: React.ReactNode;
+  labelClassName?: string;
 };
 
 export function AuraTextField({
@@ -18,6 +21,8 @@ export function AuraTextField({
   helperText,
   errorText,
   leadingIcon,
+  trailing,
+  labelClassName,
   className,
   ...props
 }: AuraTextFieldProps) {
@@ -25,11 +30,20 @@ export function AuraTextField({
 
   return (
     <View className="w-full gap-2">
-      {label ? <Text variant="label">{label}</Text> : null}
+      {label ? (
+        <Text variant="label" className={cn(labelClassName)}>
+          {label}
+        </Text>
+      ) : null}
       <View className="relative">
         {leadingIcon ? (
           <View className="absolute left-3 top-1/2 z-10 -translate-y-1/2">
             <Icon as={leadingIcon} className="text-muted-foreground" size={16} />
+          </View>
+        ) : null}
+        {trailing ? (
+          <View className="absolute right-2 top-1/2 z-10 -translate-y-1/2 flex-row items-center justify-center">
+            {trailing}
           </View>
         ) : null}
         <Input
@@ -37,6 +51,7 @@ export function AuraTextField({
           className={cn(
             'h-12 rounded-[20px] border-border bg-card px-4',
             leadingIcon && 'pl-10',
+            trailing && 'pr-12',
             hasError && 'border-destructive',
             className
           )}


### PR DESCRIPTION
## Description

Adds UI-only **login** and **signup** flows for the mobile app, aligned with the design reference (`screens/code/login_signup.html` / mockups).

- **Routes:** `/login` and `/signup` (Expo Router); **Welcome** “Get Started” navigates to `/login`.
- **Brand:** `AuraLogo` component (`apps/mobile/components/brand/aura-logo.tsx`) using `aura_logo.png`.
- **Layout:** `AuthScreenShell` (scroll, safe area, ambient background), `AuthHeaderBrand` (centered raster + “AURA” wordmark), shared footer patterns.
- **Fields:** `AuraTextField` extended with optional trailing slot (password visibility) and `labelClassName`.
- **UI primitives:** `AuraOrDivider` (“Or continue with”), `AuthSocialProviderRow` — **Google** and **Apple** only (max 2, UI-only; no OAuth wiring).
- **Navigation:** Login footer → signup; signup footer → login; centered footer copy using nested `Text` for links.

No backend or auth integrations yet.

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `chore`: Maintenance, config, or tooling
- [ ] `docs`: Documentation only
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `test`: Adding or updating tests

## Related Issue

<!-- Link to the GitHub issue if applicable, e.g. Closes #123 -->

## Screenshots

<!-- Replace the placeholders below by attaching images in the GitHub PR UI (drag-and-drop) or by replacing with image URLs after upload. -->

```text
Log in
```
<img width="1080" height="2400" alt="Screenshot_1776480343" src="https://github.com/user-attachments/assets/7365ef78-c87c-4246-b80f-f3fd60164e89" />

```text
Sign up
```
<img width="1080" height="2400" alt="Screenshot_1776480356" src="https://github.com/user-attachments/assets/393f6674-c7c1-463b-aa87-293bc8c4e724" />


## Checklist

- [x] Code follows project coding guidelines (ESLint, Prettier)
- [x] Self-review completed
- [x] Comments added for complex logic where needed
- [ ] Documentation updated if applicable
- [x] No new warnings introduced
