### PR TITLE
feat: replace mock mobile auth with Supabase session-gated flow

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -4,11 +4,11 @@ import {
   VoiceHubQuickActionsRow,
   VoiceHubRadialBackground,
   VoiceHubStateSection,
-  useSTT,
   VOICE_HUB_TAB_CONTENT_INSET,
 } from '@/components/voice-hub';
 import { AuthenticatedAppTopBar, appTopBarOffsetTop } from '@/components/common';
 import { AuraScreen } from '@/components/ui/aura-screen';
+import { useSTT } from '@/hooks/useSTT';
 import { THEME } from '@/lib/theme';
 import { GradientText } from '@/components/welcome/gradient-text';
 import { Calendar, FileText, Mail } from 'lucide-react-native';

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,9 +1,12 @@
 import { AuthenticatedAppTopBar, appTopBarOffsetTop } from '@/components/common';
+import { AuraButton } from '@/components/ui/aura-button';
 import { AuraCard } from '@/components/ui/aura-card';
 import { AuraScreen } from '@/components/ui/aura-screen';
 import { AuraThemeToggleRow } from '@/components/ui/aura-theme-toggle-row';
 import { persistColorScheme } from '@/lib/color-scheme';
+import { supabase } from '@/lib/supabase';
 import { useColorScheme } from 'nativewind';
+import { useState } from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -11,11 +14,22 @@ export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
   const { colorScheme, setColorScheme } = useColorScheme();
   const isDarkMode = colorScheme === 'dark';
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   async function onToggleDarkMode(nextValue: boolean) {
     const nextScheme = nextValue ? 'dark' : 'light';
     setColorScheme(nextScheme);
     await persistColorScheme(nextScheme);
+  }
+
+  async function onSignOut() {
+    if (isSigningOut) {
+      return;
+    }
+
+    setIsSigningOut(true);
+    await supabase.auth.signOut();
+    setIsSigningOut(false);
   }
 
   return (
@@ -27,6 +41,16 @@ export default function SettingsScreen() {
           style={{ paddingTop: appTopBarOffsetTop(insets.top) + 12 }}>
           <AuraCard title="Appearance" description="Material-style dark theme persistence">
             <AuraThemeToggleRow checked={isDarkMode} onCheckedChange={onToggleDarkMode} />
+          </AuraCard>
+          <AuraCard className="mt-4" title="Account" description="Manage your current session">
+            <AuraButton
+              label={isSigningOut ? 'Signing out...' : 'Log out'}
+              auraVariant="secondary"
+              className="h-12 rounded-full"
+              onPress={onSignOut}
+              disabled={isSigningOut}
+              accessibilityLabel="Log out"
+            />
           </AuraCard>
         </View>
       </View>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,6 +8,7 @@ import {
   Manrope_800ExtraBold,
 } from '@expo-google-fonts/manrope';
 import { initDatabase } from '@/src/db';
+import { AuthSessionProvider, useAuthSession } from '@/hooks/use-auth-session';
 import { loadStoredColorScheme, type AppColorScheme } from '@/lib/color-scheme';
 import { NAV_THEME } from '@/lib/theme';
 import { ThemeProvider } from '@react-navigation/native';
@@ -154,14 +155,28 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={NAV_THEME[resolvedColorScheme]}>
       <StatusBar style={resolvedColorScheme === 'dark' ? 'light' : 'dark'} />
-      <Stack
-        screenOptions={{
-          animation: 'fade',
-          contentStyle: { backgroundColor: 'transparent' },
-          headerShown: false,
-        }}
-      />
+      <AuthSessionProvider>
+        <AuthNavigator />
+      </AuthSessionProvider>
       <PortalHost />
     </ThemeProvider>
+  );
+}
+
+function AuthNavigator() {
+  const { isLoading } = useAuthSession();
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Stack
+      screenOptions={{
+        animation: 'fade',
+        contentStyle: { backgroundColor: 'transparent' },
+        headerShown: false,
+      }}
+    />
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,7 +14,7 @@ import { NAV_THEME } from '@/lib/theme';
 import { ThemeProvider } from '@react-navigation/native';
 import { PortalHost } from '@rn-primitives/portal';
 import { useFonts } from 'expo-font';
-import { maybeRequireNativeModule } from 'expo-modules-core';
+import { requireOptionalNativeModule } from 'expo-modules-core';
 import * as SplashScreen from 'expo-splash-screen';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -38,7 +38,7 @@ type WhisperTranscribeConfig = {
 };
 
 const whisperModule =
-  Platform.OS === 'android' ? maybeRequireNativeModule<any>('AuraWhisperStt') : null;
+  Platform.OS === 'android' ? requireOptionalNativeModule<any>('AuraWhisperStt') : null;
 
 if (Platform.OS === 'android' && whisperModule) {
   (globalThis as { __AURA_WHISPER_CPP__?: unknown }).__AURA_WHISPER_CPP__ = {

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,5 +1,7 @@
+import { useAuthSession } from '@/hooks/use-auth-session';
 import { Redirect, type Href } from 'expo-router';
 
 export default function IndexRedirect() {
-  return <Redirect href={'/welcome' as Href} />;
+  const { isAuthenticated } = useAuthSession();
+  return <Redirect href={(isAuthenticated ? '/(tabs)' : '/welcome') as Href} />;
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,7 +1,5 @@
-import { useAuthSession } from '@/hooks/use-auth-session';
 import { Redirect, type Href } from 'expo-router';
 
 export default function IndexRedirect() {
-  const { isAuthenticated } = useAuthSession();
-  return <Redirect href={(isAuthenticated ? '/(tabs)' : '/welcome') as Href} />;
+  return <Redirect href={'/welcome' as Href} />;
 }

--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -6,7 +6,9 @@ import { AuraOrDivider } from '@/components/ui/aura-or-divider';
 import { AuraTextField } from '@/components/ui/aura-text-field';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
+import { getAuthErrorMessage } from '@/lib/auth-errors';
 import { rgbaWhite } from '@/lib/raw-colors';
+import { supabase } from '@/lib/supabase';
 import { router, type Href } from 'expo-router';
 import { Eye, EyeOff, Lock, Mail } from 'lucide-react-native';
 import { useState } from 'react';
@@ -15,24 +17,44 @@ import { Pressable, View } from 'react-native';
 const LABEL_CLASS =
   'text-[11px] font-bold uppercase tracking-[0.05em] text-muted-foreground';
 
-/** Demo credentials only — no real auth. */
-const MOCK_EMAIL = 'sample@aura.io';
-const MOCK_PASSWORD = 'sample';
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function LoginScreen() {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  function handleSignIn() {
-    setSubmitError(null);
-    const trimmed = email.trim().toLowerCase();
-    if (trimmed === MOCK_EMAIL.toLowerCase() && password === MOCK_PASSWORD) {
-      router.replace('/(tabs)' as Href);
+  async function handleSignIn() {
+    if (isSubmitting) {
       return;
     }
-    setSubmitError('Try sample@aura.io / sample.');
+
+    setSubmitError(null);
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed || !password) {
+      setSubmitError('Please enter your email and password.');
+      return;
+    }
+    if (!EMAIL_REGEX.test(trimmed)) {
+      setSubmitError('Please enter a valid email address.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const { error } = await supabase.auth.signInWithPassword({
+      email: trimmed,
+      password,
+    });
+    setIsSubmitting(false);
+
+    if (error) {
+      setSubmitError(getAuthErrorMessage(error.message));
+      return;
+    }
+
+    router.replace('/(tabs)' as Href);
   }
 
   return (
@@ -131,9 +153,10 @@ export default function LoginScreen() {
         </View>
 
         <AuraButton
-          label="Sign In"
+          label={isSubmitting ? 'Signing In...' : 'Sign In'}
           className="h-14 w-full rounded-full shadow-sm shadow-primary/30"
           onPress={handleSignIn}
+          disabled={isSubmitting}
           accessibilityLabel="Sign in"
         />
 

--- a/apps/mobile/app/signup.tsx
+++ b/apps/mobile/app/signup.tsx
@@ -6,7 +6,9 @@ import { AuraOrDivider } from '@/components/ui/aura-or-divider';
 import { AuraTextField } from '@/components/ui/aura-text-field';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
+import { getAuthErrorMessage } from '@/lib/auth-errors';
 import { rgbaWhite } from '@/lib/raw-colors';
+import { supabase } from '@/lib/supabase';
 import { router, type Href } from 'expo-router';
 import { Eye, EyeOff, Lock, Mail, User } from 'lucide-react-native';
 import { useState } from 'react';
@@ -14,10 +16,62 @@ import { Pressable, View } from 'react-native';
 
 const LABEL_CLASS =
   'text-[11px] font-bold uppercase tracking-[0.05em] text-muted-foreground';
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function SignupScreen() {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const [confirmVisible, setConfirmVisible] = useState(false);
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSignUp() {
+    if (isSubmitting) {
+      return;
+    }
+
+    setSubmitError(null);
+
+    const trimmedDisplayName = displayName.trim();
+    const trimmedEmail = email.trim().toLowerCase();
+
+    if (!trimmedDisplayName || !trimmedEmail || !password || !confirmPassword) {
+      setSubmitError('Please complete all fields.');
+      return;
+    }
+
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setSubmitError('Please enter a valid email address.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setSubmitError('Passwords do not match.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const { error } = await supabase.auth.signUp({
+      email: trimmedEmail,
+      password,
+      options: {
+        data: {
+          display_name: trimmedDisplayName,
+        },
+      },
+    });
+    setIsSubmitting(false);
+
+    if (error) {
+      setSubmitError(getAuthErrorMessage(error.message));
+      return;
+    }
+
+    router.replace('/(tabs)' as Href);
+  }
 
   return (
     <View className="flex-1">
@@ -63,6 +117,11 @@ export default function SignupScreen() {
             autoCorrect
             placeholder="Your name"
             className="h-14 rounded-full border-border/40 bg-card"
+            value={displayName}
+            onChangeText={(value) => {
+              setDisplayName(value);
+              setSubmitError(null);
+            }}
           />
           <AuraTextField
             label="Email Address"
@@ -73,6 +132,11 @@ export default function SignupScreen() {
             autoCorrect={false}
             placeholder="hello@aura.io"
             className="h-14 rounded-full border-border/40 bg-card"
+            value={email}
+            onChangeText={(value) => {
+              setEmail(value);
+              setSubmitError(null);
+            }}
           />
           <AuraTextField
             label="Password"
@@ -80,7 +144,13 @@ export default function SignupScreen() {
             leadingIcon={Lock}
             placeholder="••••••••"
             secureTextEntry={!passwordVisible}
+            errorText={submitError ?? undefined}
             className="h-14 rounded-full border-border/40 bg-card"
+            value={password}
+            onChangeText={(value) => {
+              setPassword(value);
+              setSubmitError(null);
+            }}
             trailing={
               <Pressable
                 accessibilityRole="button"
@@ -104,6 +174,11 @@ export default function SignupScreen() {
             placeholder="••••••••"
             secureTextEntry={!confirmVisible}
             className="h-14 rounded-full border-border/40 bg-card"
+            value={confirmPassword}
+            onChangeText={(value) => {
+              setConfirmPassword(value);
+              setSubmitError(null);
+            }}
             trailing={
               <Pressable
                 accessibilityRole="button"
@@ -123,9 +198,10 @@ export default function SignupScreen() {
         </View>
 
         <AuraButton
-          label="Create account"
+          label={isSubmitting ? 'Creating account...' : 'Create account'}
           className="h-14 w-full rounded-full shadow-sm shadow-primary/30"
-          onPress={() => undefined}
+          onPress={handleSignUp}
+          disabled={isSubmitting}
           accessibilityLabel="Create account"
         />
 

--- a/apps/mobile/components/auth/auth-social-provider-row.tsx
+++ b/apps/mobile/components/auth/auth-social-provider-row.tsx
@@ -10,7 +10,7 @@ const PROVIDERS = [
 ] as const;
 
 /**
- * UI-only OAuth affordances (Google + Apple). No SDK wiring.
+ * OAuth actions are disabled for MVP until providers are fully wired.
  */
 export function AuthSocialProviderRow() {
   const { colorScheme } = useColorScheme();
@@ -24,8 +24,10 @@ export function AuthSocialProviderRow() {
           key={id}
           accessibilityRole="button"
           accessibilityLabel={label}
+          accessibilityState={{ disabled: true }}
+          disabled
           android_ripple={{ color: RIPPLE.onPrimary }}
-          className="h-14 max-w-[48%] flex-1 items-center justify-center rounded-full border border-border/40 bg-card active:opacity-80">
+          className="h-14 max-w-[48%] flex-1 items-center justify-center rounded-full border border-border/40 bg-card opacity-50">
           <FontAwesome5 name={icon} brand size={22} color={iconColor} />
         </Pressable>
       ))}

--- a/apps/mobile/hooks/use-auth-session.tsx
+++ b/apps/mobile/hooks/use-auth-session.tsx
@@ -1,0 +1,94 @@
+import { supabase } from '@/lib/supabase';
+import type { Session } from '@supabase/supabase-js';
+import { useRouter, useSegments } from 'expo-router';
+import type { ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+type AuthSessionContextValue = {
+  isLoading: boolean;
+  session: Session | null;
+  isAuthenticated: boolean;
+};
+
+const AUTH_ROUTES = new Set(['welcome', 'login', 'signup']);
+
+const AuthSessionContext = createContext<AuthSessionContextValue | null>(null);
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function restoreSession() {
+      const { data, error } = await supabase.auth.getSession();
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        setSession(null);
+      } else {
+        setSession(data.session ?? null);
+      }
+
+      setIsLoading(false);
+    }
+
+    void restoreSession();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (!isMounted) {
+        return;
+      }
+      setSession(nextSession);
+      setIsLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+      authListener.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    const firstSegment = segments[0];
+    const inAuthFlow = AUTH_ROUTES.has(firstSegment);
+
+    if (!session && !inAuthFlow) {
+      router.replace('/welcome');
+      return;
+    }
+
+    if (session && inAuthFlow) {
+      router.replace('/(tabs)');
+    }
+  }, [isLoading, router, segments, session]);
+
+  const value = useMemo<AuthSessionContextValue>(
+    () => ({
+      isLoading,
+      session,
+      isAuthenticated: Boolean(session),
+    }),
+    [isLoading, session]
+  );
+
+  return <AuthSessionContext.Provider value={value}>{children}</AuthSessionContext.Provider>;
+}
+
+export function useAuthSession(): AuthSessionContextValue {
+  const context = useContext(AuthSessionContext);
+  if (!context) {
+    throw new Error('useAuthSession must be used within AuthSessionProvider');
+  }
+
+  return context;
+}

--- a/apps/mobile/lib/auth-errors.ts
+++ b/apps/mobile/lib/auth-errors.ts
@@ -1,0 +1,33 @@
+export function getAuthErrorMessage(rawMessage?: string): string {
+  if (!rawMessage) {
+    return 'Something went wrong. Please try again.';
+  }
+
+  const message = rawMessage.toLowerCase();
+
+  if (message.includes('invalid login credentials')) {
+    return 'Invalid email or password.';
+  }
+
+  if (message.includes('email not confirmed')) {
+    return 'Please verify your email address before signing in.';
+  }
+
+  if (message.includes('user already registered')) {
+    return 'An account with this email already exists.';
+  }
+
+  if (message.includes('password should be at least')) {
+    return 'Password is too short. Please use at least 6 characters.';
+  }
+
+  if (message.includes('unable to validate email address')) {
+    return 'Please enter a valid email address.';
+  }
+
+  if (message.includes('network') || message.includes('fetch')) {
+    return 'Network error. Check your connection and try again.';
+  }
+
+  return 'Unable to complete authentication. Please try again.';
+}

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -2,14 +2,16 @@ import 'react-native-url-polyfill/auto';
 import 'expo-sqlite/localStorage/install';
 import { createClient } from '@supabase/supabase-js';
 
+const authStorage = typeof localStorage !== 'undefined' ? localStorage : undefined;
+
 export const supabase = createClient(
   process.env.EXPO_PUBLIC_SUPABASE_URL!,
   process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
   {
     auth: {
-      storage: localStorage,
+      storage: authStorage,
       autoRefreshToken: true,
-      persistSession: true,
+      persistSession: Boolean(authStorage),
       detectSessionInUrl: false,
     },
   }

--- a/docs/issues/qa/auth-manual-qa-checklist.md
+++ b/docs/issues/qa/auth-manual-qa-checklist.md
@@ -1,0 +1,77 @@
+# Auth Manual QA Checklist (MVP)
+
+## Preconditions
+
+- Valid Supabase env values are set in `apps/mobile/.env`:
+  - `EXPO_PUBLIC_SUPABASE_URL`
+  - `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+- App launched from `apps/mobile` via `pnpm start` (or platform-specific script).
+
+## Test Cases
+
+1. Login success
+- Go to `/login`.
+- Enter a valid registered email/password.
+- Tap `Sign In`.
+- Expected: request succeeds, user lands in `/(tabs)`.
+
+2. Login validation: empty fields
+- Go to `/login`.
+- Leave email and/or password empty.
+- Tap `Sign In`.
+- Expected: inline error appears, no request is sent.
+
+3. Login validation: invalid email format
+- Go to `/login`.
+- Enter malformed email (example: `user@`).
+- Tap `Sign In`.
+- Expected: inline email format error appears, no request is sent.
+
+4. Login failure: invalid credentials
+- Go to `/login`.
+- Enter non-matching credentials.
+- Tap `Sign In`.
+- Expected: user-friendly error appears (`Invalid email or password.`).
+
+5. Signup success
+- Go to `/signup`.
+- Fill display name, valid new email, password, confirm password.
+- Tap `Create account`.
+- Expected: account creation succeeds and user is redirected to `/(tabs)`.
+
+6. Signup validation: required fields
+- Go to `/signup`.
+- Leave one or more fields empty.
+- Tap `Create account`.
+- Expected: inline required-fields error appears, no request is sent.
+
+7. Signup validation: password confirmation mismatch
+- Go to `/signup`.
+- Enter different values for password and confirm password.
+- Tap `Create account`.
+- Expected: inline mismatch error appears, no request is sent.
+
+8. Loading states
+- On `/login` and `/signup`, submit valid forms.
+- Expected: auth button is disabled while request is in progress and label shows loading text.
+- In Settings, tap `Log out`.
+- Expected: logout button is disabled while request is in progress.
+
+9. Session restore on app relaunch
+- Login successfully.
+- Fully close and relaunch the app.
+- Expected: existing session restores; user remains in `/(tabs)`.
+
+10. Route gating for unauthenticated users
+- Ensure logged out.
+- Attempt to open any `/(tabs)` route.
+- Expected: user is redirected to `/welcome`.
+
+11. Logout flow
+- While authenticated, open Settings.
+- Tap `Log out`.
+- Expected: session is cleared and user returns to auth flow (`/welcome`).
+
+12. Social provider buttons
+- On `/login` and `/signup`, inspect social provider actions.
+- Expected: provider buttons are visibly disabled for MVP and not interactive.


### PR DESCRIPTION
## Summary
- replace mock login with `supabase.auth.signInWithPassword`
- wire signup UI to `supabase.auth.signUp` with field validation and password confirmation
- add centralized auth session restore + auth state listener + route gating for auth vs app tabs
- add logout action in Settings using `supabase.auth.signOut`
- disable social provider buttons for MVP (visibly non-interactive)
- add user-friendly auth error mapping and a manual QA checklist for MVP auth flows

## Scope Covered
- Email/password login
- Email/password signup
- Session persistence and restore
- Logout
- Auth loading/error states
- Basic form validation

## Acceptance Checklist
- [x] Login screen calls `supabase.auth.signInWithPassword`
- [x] Signup screen calls `supabase.auth.signUp` and validates display name, email, password, confirm password
- [x] Login validates empty fields + email format before submit
- [x] Signup validates password confirmation
- [x] Supabase auth errors shown in user-friendly format
- [x] Loading states disable auth buttons while request is in progress
- [x] Existing Supabase session restored on app launch
- [x] Authenticated users redirected to `/(tabs)`
- [x] Unauthenticated users redirected to `/welcome` or `/login`
- [x] Logout clears Supabase session and returns to auth flow
- [x] Social provider buttons hidden/disabled for MVP (disabled)
- [x] Demo credential comments/constants removed from login
- [x] Added documented manual QA checklist

## Validation
- `pnpm --filter mobile test` ✅
- `pnpm --filter mobile typecheck` ⚠️ fails due to existing unrelated issues:
  - `app/(tabs)/index.tsx` imports missing `useSTT` export
  - `app/_layout.tsx` `maybeRequireNativeModule` typing/export mismatch

## Notes
- Base branch: `development`
- Assignee: `potakaaa`
