### PR TITLE
fix: align Android STT Expo bridge with AuraWhisperStt module

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -3,12 +3,14 @@ import { AuraCard } from '@/components/ui/aura-card';
 import { AuraScreen } from '@/components/ui/aura-screen';
 import { AuraThemeToggleRow } from '@/components/ui/aura-theme-toggle-row';
 import { persistColorScheme } from '@/lib/color-scheme';
+import { useRouter } from 'expo-router';
 import { useColorScheme } from 'nativewind';
-import { View } from 'react-native';
+import { Button, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const { colorScheme, setColorScheme } = useColorScheme();
   const isDarkMode = colorScheme === 'dark';
 
@@ -28,6 +30,12 @@ export default function SettingsScreen() {
           <AuraCard title="Appearance" description="Material-style dark theme persistence">
             <AuraThemeToggleRow checked={isDarkMode} onCheckedChange={onToggleDarkMode} />
           </AuraCard>
+          <View className="mt-4">
+            <Button
+              title="Open STT Test (Temporary)"
+              onPress={() => router.push('/dev/stt-test')}
+            />
+          </View>
         </View>
       </View>
     </AuraScreen>

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -4,10 +4,8 @@ import { AuraCard } from '@/components/ui/aura-card';
 import { AuraScreen } from '@/components/ui/aura-screen';
 import { AuraThemeToggleRow } from '@/components/ui/aura-theme-toggle-row';
 import { persistColorScheme } from '@/lib/color-scheme';
-import { useRouter } from 'expo-router';
-import { useColorScheme } from 'nativewind';
-import { Button, View } from 'react-native';
 import { supabase } from '@/lib/supabase';
+import { useRouter } from 'expo-router';
 import { useColorScheme } from 'nativewind';
 import { useState } from 'react';
 import { View } from 'react-native';
@@ -47,9 +45,12 @@ export default function SettingsScreen() {
             <AuraThemeToggleRow checked={isDarkMode} onCheckedChange={onToggleDarkMode} />
           </AuraCard>
           <View className="mt-4">
-            <Button
-              title="Open STT Test (Temporary)"
+            <AuraButton
+              label="Open STT Test (Temporary)"
+              auraVariant="secondary"
+              className="h-12 rounded-full"
               onPress={() => router.push('/dev/stt-test')}
+              accessibilityLabel="Open STT Test"
             />
           </View>
           <AuraCard className="mt-4" title="Account" description="Manage your current session">

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -13,7 +13,6 @@ import { NAV_THEME } from '@/lib/theme';
 import { ThemeProvider } from '@react-navigation/native';
 import { PortalHost } from '@rn-primitives/portal';
 import { useFonts } from 'expo-font';
-import { maybeRequireNativeModule } from 'expo-modules-core';
 import * as SplashScreen from 'expo-splash-screen';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -22,33 +21,6 @@ import { useEffect, useState } from 'react';
 import { Platform, Text, View } from 'react-native';
 
 void SplashScreen.preventAutoHideAsync();
-
-type WhisperStartCaptureConfig = {
-  sampleRateHz: 16000;
-  channelCount: 1;
-  maxDurationSeconds: number;
-  language: 'en';
-};
-
-type WhisperTranscribeConfig = {
-  pcm16kMono: number[];
-  language: 'en';
-  environment: 'quiet' | 'noisy';
-};
-
-const whisperModule =
-  Platform.OS === 'android' ? maybeRequireNativeModule<any>('AuraWhisperStt') : null;
-
-if (Platform.OS === 'android' && whisperModule) {
-  (globalThis as { __AURA_WHISPER_CPP__?: unknown }).__AURA_WHISPER_CPP__ = {
-    startCapture: (config: WhisperStartCaptureConfig) =>
-      whisperModule.startCapture(config.maxDurationSeconds, config.language),
-    stopCapture: () => whisperModule.stopCapture(),
-    readCapturedPcm16kMono: () => whisperModule.readCapturedPcm16kMono(),
-    transcribe: (config: WhisperTranscribeConfig) =>
-      whisperModule.transcribe(config.pcm16kMono, config.language, config.environment),
-  };
-}
 
 export {
   // Catch any errors thrown by the Layout component.

--- a/apps/mobile/components/voice-hub/index.ts
+++ b/apps/mobile/components/voice-hub/index.ts
@@ -3,3 +3,4 @@ export { VoiceHubOrb } from './voice-hub-orb';
 export { VoiceHubQuickAction, VoiceHubQuickActionsRow } from './voice-hub-quick-action';
 export { VoiceHubStateSection } from './voice-hub-state-section';
 export { VoiceHubTabBar, VOICE_HUB_TAB_CONTENT_INSET } from './voice-hub-tab-bar';
+export { useSTT } from '../../hooks/useSTT';

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -21,6 +21,9 @@
     "stt:benchmark:device": "node stt/benchmarks/run-device-benchmark.mjs",
     "stt:smoke": "node stt/smoke/run-smoke.mjs"
   },
+  "dependencies": {
+    "expo-modules-core": "3.0.29"
+  },
   "devDependencies": {
     "vitest": "^4.1.2",
     "typescript": "^5.8.3"

--- a/packages/voice/stt/adapters/androidWhisperCpp.test.ts
+++ b/packages/voice/stt/adapters/androidWhisperCpp.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AndroidWhisperCppCapture, AndroidWhisperCppEngine } from "./androidWhisperCpp.js";
+
+const nativeModuleMock = {
+  startCapture: vi.fn(async () => {}),
+  stopCapture: vi.fn(async () => {}),
+  readCapturedPcm16kMono: vi.fn(async () => [1, -2, 3]),
+  transcribe: vi.fn(async () => ({
+    transcript: "hello world",
+    latencyMs: 123,
+    confidence: 0.87,
+  })),
+};
+
+vi.mock("expo-modules-core", () => ({
+  requireNativeModule: vi.fn(() => nativeModuleMock),
+}));
+
+describe("AndroidWhisperCpp adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls startCapture with positional args", async () => {
+    const capture = new AndroidWhisperCppCapture();
+
+    await capture.start(
+      {
+        utteranceId: "u-1",
+        language: "en",
+        environment: "quiet",
+        maxDurationSeconds: 15,
+      },
+      async () => {},
+    );
+
+    expect(nativeModuleMock.startCapture).toHaveBeenCalledWith(15, "en");
+  });
+
+  it("calls transcribe with positional args", async () => {
+    const engine = new AndroidWhisperCppEngine("base");
+
+    const result = await engine.transcribeChunk(
+      {
+        pcm16kMono: Int16Array.from([5, -7, 10]),
+        startMs: 1000,
+        endMs: 1200,
+      },
+      {
+        utteranceId: "u-1",
+        language: "en",
+        environment: "noisy",
+        maxDurationSeconds: 20,
+      },
+    );
+
+    expect(nativeModuleMock.transcribe).toHaveBeenCalledWith([5, -7, 10], "en", "noisy");
+    expect(result.transcript).toBe("hello world");
+  });
+});

--- a/packages/voice/stt/adapters/androidWhisperCpp.ts
+++ b/packages/voice/stt/adapters/androidWhisperCpp.ts
@@ -6,21 +6,17 @@ import type {
   SttTranscriptionRequest,
   SttTranscriptionResult,
 } from "../types.js";
+import { requireNativeModule } from "expo-modules-core";
 
 interface AndroidWhisperCppNativeModule {
-  startCapture(config: {
-    readonly sampleRateHz: 16000;
-    readonly channelCount: 1;
-    readonly maxDurationSeconds: number;
-    readonly language: "en";
-  }): Promise<void>;
+  startCapture(maxDurationSeconds: number, language: "en"): Promise<void>;
   stopCapture(): Promise<void>;
   readCapturedPcm16kMono(): Promise<number[]>;
-  transcribe(config: {
-    readonly pcm16kMono: number[];
-    readonly language: "en";
-    readonly environment: "quiet" | "noisy";
-  }): Promise<{
+  transcribe(
+    pcm16kMono: number[],
+    language: "en",
+    environment: "quiet" | "noisy",
+  ): Promise<{
     readonly transcript: string;
     readonly latencyMs: number;
     readonly confidence?: number;
@@ -28,17 +24,15 @@ interface AndroidWhisperCppNativeModule {
 }
 
 function getNativeModule(): AndroidWhisperCppNativeModule {
-  const maybeModule = (globalThis as { __AURA_WHISPER_CPP__?: AndroidWhisperCppNativeModule })
-    .__AURA_WHISPER_CPP__;
-
-  if (!maybeModule) {
+  try {
+    return requireNativeModule<AndroidWhisperCppNativeModule>("AuraWhisperStt");
+  } catch {
     throw new Error(
-      "Android whisper.cpp native module is not registered. " +
-        "Attach `__AURA_WHISPER_CPP__` from native bridge initialization.",
+      "Android whisper.cpp native module `AuraWhisperStt` is unavailable. " +
+        "This requires an Android dev/client build with the native module compiled in; " +
+        "Expo Go does not include custom native modules.",
     );
   }
-
-  return maybeModule;
 }
 
 export class AndroidWhisperCppCapture implements SttAudioCapture {
@@ -46,12 +40,7 @@ export class AndroidWhisperCppCapture implements SttAudioCapture {
     request: SttTranscriptionRequest,
     _onChunk: (chunk: SttAudioChunk) => Promise<void>,
   ): Promise<void> {
-    await getNativeModule().startCapture({
-      sampleRateHz: 16000,
-      channelCount: 1,
-      maxDurationSeconds: request.maxDurationSeconds,
-      language: request.language,
-    });
+    await getNativeModule().startCapture(request.maxDurationSeconds, request.language);
   }
 
   public async stop(): Promise<void> {
@@ -86,11 +75,11 @@ export class AndroidWhisperCppEngine implements SttEngine {
     chunk: SttAudioChunk,
     request: SttTranscriptionRequest,
   ): Promise<SttTranscriptionResult> {
-    const response = await getNativeModule().transcribe({
-      pcm16kMono: Array.from(chunk.pcm16kMono),
-      language: request.language,
-      environment: request.environment,
-    });
+    const response = await getNativeModule().transcribe(
+      Array.from(chunk.pcm16kMono),
+      request.language,
+      request.environment,
+    );
 
     return {
       utteranceId: request.utteranceId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,10 @@ importers:
         version: 5.9.3
 
   packages/voice:
+    dependencies:
+      expo-modules-core:
+        specifier: 3.0.29
+        version: 3.0.29(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     devDependencies:
       typescript:
         specifier: ^5.8.3


### PR DESCRIPTION
## Summary
- switch STT adapter to Expo native module lookup via requireNativeModule("AuraWhisperStt")
- align adapter calls to Kotlin positional signatures for capture and transcribe
- remove legacy __AURA_WHISPER_CPP__ bridge bootstrap and add adapter-level native-call shape tests

## Validation
- pnpm --filter @aura/voice build
- pnpm --filter @aura/voice test
- pnpm --filter mobile typecheck